### PR TITLE
feat: print file + mockup pipeline

### DIFF
--- a/drizzle/0001_add_mockup_key.sql
+++ b/drizzle/0001_add_mockup_key.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "drop" ADD COLUMN "mockup_key" text;

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,10 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   images: {
-    remotePatterns: [{ protocol: "https", hostname: "**.printful.com" }],
+    remotePatterns: [
+      { protocol: "https", hostname: "**.printful.com" },
+      { protocol: "https", hostname: "**.r2.cloudflarestorage.com" },
+    ],
   },
 };
 

--- a/src/app/[creatorSlug]/[dropSlug]/page.tsx
+++ b/src/app/[creatorSlug]/[dropSlug]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation"
 import Image from "next/image"
 import { getDropBySlug } from "@/lib/drops"
+import { getSignedUrl } from "@/lib/storage"
 import { calculatePrice, BASE_SHIRT_COST_CENTS } from "@/lib/pricing"
 import { BuyForm } from "@/components/drops/buy-form"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
@@ -15,6 +16,7 @@ export default async function PublicDropPage({ params }: Props) {
   if (!result) notFound()
 
   const { drop } = result
+  const mockupUrl = drop.mockupKey ? await getSignedUrl(drop.mockupKey) : null
 
   if (drop.status === "pre_live") {
     return (
@@ -72,9 +74,9 @@ export default async function PublicDropPage({ params }: Props) {
       <div className="w-full max-w-4xl">
         <div className="grid gap-8 md:grid-cols-2">
           <div className="overflow-hidden rounded-xl bg-muted">
-            {drop.mockupUrl ? (
+            {mockupUrl ? (
               <Image
-                src={drop.mockupUrl}
+                src={mockupUrl}
                 alt={drop.title}
                 width={600}
                 height={600}

--- a/src/app/drops/[id]/design/actions.ts
+++ b/src/app/drops/[id]/design/actions.ts
@@ -1,0 +1,60 @@
+"use server"
+
+import { headers } from "next/headers"
+import { auth } from "@/lib/auth"
+import { getDrop, updateDrop } from "@/lib/drops"
+import { storageKeys, getPresignedUploadUrl } from "@/lib/storage"
+import { compositePrintFile, PRINT_CANVAS } from "@/lib/compositor"
+import { generateMockup } from "@/lib/mockup"
+import { TSHIRT_DISPLAY, PRINT_AREA, type Placement } from "@/lib/design-constants"
+
+const printAreaPxW = TSHIRT_DISPLAY * PRINT_AREA.width
+const printAreaPxH = TSHIRT_DISPLAY * PRINT_AREA.height
+
+async function getAuthorizedDrop(dropId: string) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) throw new Error("Unauthorized")
+
+  const drop = await getDrop(dropId)
+  if (!drop || drop.userId !== session.user.id) throw new Error("Not found")
+
+  return drop
+}
+
+export async function getDesignUploadUrl(dropId: string) {
+  const drop = await getAuthorizedDrop(dropId)
+  if (drop.firstSaleAt) throw new Error("Design locked after first sale")
+
+  const key = storageKeys.design(`${dropId}-${Date.now()}.png`)
+  const uploadUrl = await getPresignedUploadUrl(key, "image/png")
+
+  return { uploadUrl, fileKey: key }
+}
+
+export async function runPipeline(
+  dropId: string,
+  designFileKey: string,
+  editorPlacement: Placement
+) {
+  const drop = await getAuthorizedDrop(dropId)
+  if (drop.firstSaleAt) throw new Error("Design locked after first sale")
+
+  const kX = PRINT_CANVAS.width / printAreaPxW
+  const kY = PRINT_CANVAS.height / printAreaPxH
+
+  const compositorPlacement = {
+    x: editorPlacement.x * kX,
+    y: editorPlacement.y * kY,
+    scale: editorPlacement.scale * kX,
+    rotate: editorPlacement.rotate,
+  }
+
+  await updateDrop(dropId, { designFileKey, placement: editorPlacement })
+
+  const printFileKey = await compositePrintFile(designFileKey, compositorPlacement)
+  await updateDrop(dropId, { printFileKey })
+
+  const mockupUrl = await generateMockup(dropId)
+
+  return { mockupUrl }
+}

--- a/src/app/drops/[id]/design/page.tsx
+++ b/src/app/drops/[id]/design/page.tsx
@@ -2,6 +2,7 @@ import { redirect, notFound } from "next/navigation"
 import { headers } from "next/headers"
 import { auth } from "@/lib/auth"
 import { getDrop } from "@/lib/drops"
+import { getSignedUrl } from "@/lib/storage"
 import { DesignStep } from "@/components/drops/design-step"
 
 export default async function DesignPage({
@@ -28,7 +29,7 @@ export default async function DesignPage({
         </div>
         <DesignStep
           dropId={id}
-          initialMockupUrl={drop.mockupUrl ?? undefined}
+          initialMockupUrl={drop.mockupKey ? await getSignedUrl(drop.mockupKey) : undefined}
           locked={!!drop.firstSaleAt}
         />
       </div>

--- a/src/app/drops/[id]/design/page.tsx
+++ b/src/app/drops/[id]/design/page.tsx
@@ -2,31 +2,35 @@ import { redirect, notFound } from "next/navigation"
 import { headers } from "next/headers"
 import { auth } from "@/lib/auth"
 import { getDrop } from "@/lib/drops"
-import { DesignEditorStep } from "@/components/drops/design-editor-step"
+import { DesignStep } from "@/components/drops/design-step"
 
 export default async function DesignPage({
   params,
 }: {
   params: Promise<{ id: string }>
 }) {
+  const { id } = await params
+
   const session = await auth.api.getSession({ headers: await headers() })
   if (!session) redirect("/login")
 
-  const { id } = await params
   const drop = await getDrop(id)
-  if (!drop) notFound()
-  if (drop.userId !== session.user.id) notFound()
+  if (!drop || drop.userId !== session.user.id) notFound()
 
   return (
     <main className="min-h-screen p-8">
       <div className="mx-auto max-w-xl space-y-8">
         <div>
-          <h1 className="text-2xl font-semibold">Upload your design</h1>
+          <h1 className="text-2xl font-semibold">Design your drop</h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            Place your PNG design on the shirt, then save.
+            Upload your design and preview how it looks on the shirt.
           </p>
         </div>
-        <DesignEditorStep dropId={id} locked={drop.firstSaleAt !== null} />
+        <DesignStep
+          dropId={id}
+          initialMockupUrl={drop.mockupUrl ?? undefined}
+          locked={!!drop.firstSaleAt}
+        />
       </div>
     </main>
   )

--- a/src/components/design-editor.tsx
+++ b/src/components/design-editor.tsx
@@ -18,15 +18,15 @@ import {
   PRINT_AREA,
   PRINT_INCHES_W,
   PRINT_INCHES_H,
+  TSHIRT_DISPLAY,
+  type Placement,
+} from "@/lib/design-constants"
+import {
   computeInitScale,
   computeEffectiveDPI,
   computePrintedWidthIn,
-  type Placement,
   useDesignEditor,
 } from "@/hooks/use-design-editor"
-
-// Display size of the t-shirt image inside the modal
-const TSHIRT_DISPLAY = 320
 
 interface DesignEditorProps {
   onChange?: (placement: Placement | null) => void

--- a/src/components/drops/design-step.tsx
+++ b/src/components/drops/design-step.tsx
@@ -1,0 +1,92 @@
+"use client"
+
+import { useState } from "react"
+import Link from "next/link"
+import { DesignEditor } from "@/components/design-editor"
+import { Button } from "@/components/ui/button"
+import { getDesignUploadUrl, runPipeline } from "@/app/drops/[id]/design/actions"
+import type { Placement } from "@/lib/design-constants"
+
+type Phase = "idle" | "uploading" | "processing" | "preview"
+
+export function DesignStep({
+  dropId,
+  initialMockupUrl,
+  locked,
+}: {
+  dropId: string
+  initialMockupUrl?: string
+  locked: boolean
+}) {
+  const [phase, setPhase] = useState<Phase>(initialMockupUrl ? "preview" : "idle")
+  const [placement, setPlacement] = useState<Placement | null>(null)
+  const [file, setFile] = useState<File | null>(null)
+  const [mockupUrl, setMockupUrl] = useState<string | null>(initialMockupUrl ?? null)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleGenerate() {
+    if (!file || !placement) return
+    setError(null)
+    try {
+      setPhase("uploading")
+      const { uploadUrl, fileKey } = await getDesignUploadUrl(dropId)
+      await fetch(uploadUrl, {
+        method: "PUT",
+        body: file,
+        headers: { "Content-Type": "image/png" },
+      })
+      setPhase("processing")
+      const { mockupUrl: newMockupUrl } = await runPipeline(dropId, fileKey, placement)
+      setMockupUrl(newMockupUrl)
+      setPhase("preview")
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong")
+      setPhase("idle")
+    }
+  }
+
+  if (locked && mockupUrl) {
+    return (
+      <div className="space-y-4">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={mockupUrl} alt="Mockup" className="rounded-lg border" />
+        <p className="text-sm text-muted-foreground">Design locked after first sale.</p>
+      </div>
+    )
+  }
+
+  if (phase === "uploading") {
+    return <p className="text-sm text-muted-foreground animate-pulse">Uploading design…</p>
+  }
+
+  if (phase === "processing") {
+    return <p className="text-sm text-muted-foreground animate-pulse">Generating mockup…</p>
+  }
+
+  if (phase === "preview" && mockupUrl) {
+    return (
+      <div className="space-y-4">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={mockupUrl} alt="Mockup" className="rounded-lg border" />
+        <div className="flex gap-3">
+          <Button variant="outline" onClick={() => setPhase("idle")}>
+            Edit placement
+          </Button>
+          <Button asChild>
+            <Link href={`/drops/${dropId}/publish`}>Continue →</Link>
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <DesignEditor onChange={setPlacement} onFileChange={setFile} />
+      {error && <p className="text-sm text-destructive">{error}</p>}
+      <Button disabled={!file || !placement} onClick={handleGenerate}>
+        Generate mockup
+      </Button>
+    </div>
+  )
+}

--- a/src/components/drops/design-step.tsx
+++ b/src/components/drops/design-step.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react"
 import Link from "next/link"
 import { DesignEditor } from "@/components/design-editor"
-import { Button } from "@/components/ui/button"
+import { Button, buttonVariants } from "@/components/ui/button"
 import { getDesignUploadUrl, runPipeline } from "@/app/drops/[id]/design/actions"
 import type { Placement } from "@/lib/design-constants"
 
@@ -72,9 +72,7 @@ export function DesignStep({
           <Button variant="outline" onClick={() => setPhase("idle")}>
             Edit placement
           </Button>
-          <Button asChild>
-            <Link href={`/drops/${dropId}/publish`}>Continue →</Link>
-          </Button>
+          <Link href={`/drops/${dropId}/publish`} className={buttonVariants()}>Continue →</Link>
         </div>
       </div>
     )

--- a/src/hooks/use-design-editor.ts
+++ b/src/hooks/use-design-editor.ts
@@ -2,21 +2,23 @@
 
 import { useRef, useState } from "react"
 import type { ReactZoomPanPinchRef } from "react-zoom-pan-pinch"
+import {
+  PRINT_INCHES_W,
+  PRINT_AREA,
+  MIN_DPI,
+  type Placement,
+} from "@/lib/design-constants"
 
-// BC 3001 front print area: 12" × 16" @ 150 DPI minimum
-export const PRINT_INCHES_W = 12
-export const PRINT_INCHES_H = 16
-export const MIN_DPI = 150
-export const MIN_PX_W = PRINT_INCHES_W * MIN_DPI // 1800
-export const MIN_PX_H = PRINT_INCHES_H * MIN_DPI // 2400
-
-// Print area position on the 1000×1000 t-shirt template (fraction of image size)
-export const PRINT_AREA = {
-  left: 0.30,
-  top: 0.24,
-  width: 0.40,
-  height: 0.53,
-} as const
+export {
+  PRINT_INCHES_W,
+  PRINT_INCHES_H,
+  MIN_DPI,
+  MIN_PX_W,
+  MIN_PX_H,
+  PRINT_AREA,
+  TSHIRT_DISPLAY,
+  type Placement,
+} from "@/lib/design-constants"
 
 // Pure math helpers — exported for testing
 export function computeInitScale(
@@ -41,16 +43,9 @@ export function computePrintedWidthIn(
   return (naturalW * scale / printAreaPxW) * PRINT_INCHES_W
 }
 
-export type Placement = {
-  x: number
-  y: number
-  scale: number
-  rotate: number
-}
-
 export function useDesignEditor(
   onChange?: (placement: Placement | null) => void,
-  onFileChange?: (file: File) => void,
+  onFileChange?: (file: File) => void
 ) {
   const [imageUrl, setImageUrl] = useState<string | null>(null)
   const [naturalW, setNaturalW] = useState(0)
@@ -58,6 +53,7 @@ export function useDesignEditor(
   const [uploadError, setUploadError] = useState<string | null>(null)
   const [isOpen, setIsOpen] = useState(false)
   const [rotate, setRotate] = useState(0)
+  const [currentFile, setCurrentFile] = useState<File | null>(null)
 
   const transformRef = useRef<ReactZoomPanPinchRef>(null)
   const replaceInputRef = useRef<HTMLInputElement>(null)
@@ -68,6 +64,7 @@ export function useDesignEditor(
       return
     }
     setUploadError(null)
+    setCurrentFile(file)
 
     const url = URL.createObjectURL(file)
     const img = new window.Image()
@@ -133,6 +130,7 @@ export function useDesignEditor(
     uploadError,
     isOpen,
     rotate,
+    currentFile,
     transformRef,
     replaceInputRef,
     handleFileChange,

--- a/src/lib/compositor.ts
+++ b/src/lib/compositor.ts
@@ -8,6 +8,7 @@ export type Placement = {
   x: number;
   y: number;
   scale: number;
+  rotate: number;
 };
 
 export async function compositePrintFile(
@@ -16,14 +17,19 @@ export async function compositePrintFile(
 ): Promise<string> {
   const designBuffer = await downloadFile(designKey);
 
-  const designMeta = await sharp(designBuffer).metadata();
+  let workingBuffer = designBuffer;
+  if (placement.rotate !== 0) {
+    workingBuffer = await sharp(designBuffer).rotate(placement.rotate).toBuffer();
+  }
+
+  const designMeta = await sharp(workingBuffer).metadata();
   const designWidth = designMeta.width ?? 0;
   const designHeight = designMeta.height ?? 0;
 
   const scaledWidth = Math.round(designWidth * placement.scale);
   const scaledHeight = Math.round(designHeight * placement.scale);
 
-  const resized = await sharp(designBuffer)
+  const resized = await sharp(workingBuffer)
     .resize(scaledWidth, scaledHeight, { fit: "fill" })
     .png()
     .toBuffer();

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -39,7 +39,7 @@ export const drop = pgTable(
     designFileKey: text("design_file_key"),
     printFileKey: text("print_file_key"),
     mockupUrl: text("mockup_url"),
-    placement: json("placement").$type<{ x: number; y: number; scale: number }>(),
+    placement: json("placement").$type<{ x: number; y: number; scale: number; rotate: number }>(),
     firstSaleAt: timestamp("first_sale_at"),
     createdAt: timestamp("created_at").notNull().defaultNow(),
     updatedAt: timestamp("updated_at").notNull().defaultNow(),

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -39,6 +39,7 @@ export const drop = pgTable(
     designFileKey: text("design_file_key"),
     printFileKey: text("print_file_key"),
     mockupUrl: text("mockup_url"),
+    mockupKey: text("mockup_key"),
     placement: json("placement").$type<{ x: number; y: number; scale: number; rotate: number }>(),
     firstSaleAt: timestamp("first_sale_at"),
     createdAt: timestamp("created_at").notNull().defaultNow(),

--- a/src/lib/design-constants.ts
+++ b/src/lib/design-constants.ts
@@ -1,0 +1,24 @@
+// BC 3001 front print area: 12" × 16" @ 150 DPI minimum
+export const PRINT_INCHES_W = 12
+export const PRINT_INCHES_H = 16
+export const MIN_DPI = 150
+export const MIN_PX_W = PRINT_INCHES_W * MIN_DPI // 1800
+export const MIN_PX_H = PRINT_INCHES_H * MIN_DPI // 2400
+
+// Print area position on the 1000×1000 t-shirt template (fraction of image size)
+export const PRINT_AREA = {
+  left: 0.30,
+  top: 0.24,
+  width: 0.40,
+  height: 0.53,
+} as const
+
+// Display size of the t-shirt image inside the modal
+export const TSHIRT_DISPLAY = 320
+
+export type Placement = {
+  x: number
+  y: number
+  scale: number
+  rotate: number
+}

--- a/src/lib/drops.ts
+++ b/src/lib/drops.ts
@@ -29,6 +29,7 @@ export type UpdateDropParams = {
   designFileKey?: string
   printFileKey?: string
   mockupUrl?: string
+  mockupKey?: string
   placement?: { x: number; y: number; scale: number; rotate: number }
   status?: "pre_live" | "live" | "closed"
 }

--- a/src/lib/mockup.ts
+++ b/src/lib/mockup.ts
@@ -2,7 +2,7 @@ import { eq } from "drizzle-orm"
 import { db } from "@/lib/db"
 import { drop } from "@/lib/db/schema"
 import { generateMockup as printfulGenerateMockup } from "@/lib/printful"
-import { getSignedUrl } from "@/lib/storage"
+import { getSignedUrl, uploadFile, storageKeys } from "@/lib/storage"
 
 // BC3001 White M — representative variant for white shirt mockup
 const BC3001_WHITE_VARIANT_ID = 4012
@@ -13,12 +13,18 @@ export async function generateMockup(dropId: string): Promise<string> {
   if (!record.printFileKey) throw new Error(`Drop has no print file: ${dropId}`)
 
   // After first sale, return cached mockup — never regenerate
-  if (record.firstSaleAt && record.mockupUrl) return record.mockupUrl
+  if (record.firstSaleAt && record.mockupKey) return getSignedUrl(record.mockupKey)
 
   const printFileUrl = await getSignedUrl(record.printFileKey)
-  const mockupUrl = await printfulGenerateMockup(printFileUrl, [BC3001_WHITE_VARIANT_ID])
+  const printfulUrl = await printfulGenerateMockup(printFileUrl, [BC3001_WHITE_VARIANT_ID])
 
-  await db.update(drop).set({ mockupUrl, updatedAt: new Date() }).where(eq(drop.id, dropId))
+  const res = await fetch(printfulUrl)
+  if (!res.ok) throw new Error(`Failed to fetch mockup from Printful: ${res.status}`)
+  const buffer = Buffer.from(await res.arrayBuffer())
+  const mockupKey = storageKeys.mockup(`${dropId}-${Date.now()}.png`)
+  await uploadFile(mockupKey, buffer, "image/png")
 
-  return mockupUrl
+  await db.update(drop).set({ mockupKey, updatedAt: new Date() }).where(eq(drop.id, dropId))
+
+  return getSignedUrl(mockupKey)
 }

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -16,6 +16,8 @@ function getClient(): S3Client {
       accessKeyId: process.env.R2_ACCESS_KEY_ID!,
       secretAccessKey: process.env.R2_SECRET_ACCESS_KEY!,
     },
+    requestChecksumCalculation: "WHEN_REQUIRED" as never,
+    responseChecksumValidation: "WHEN_REQUIRED" as never,
   });
 }
 
@@ -73,4 +75,5 @@ export async function getSignedUrl(key: string): Promise<string> {
 export const storageKeys = {
   design: (id: string) => `designs/${id}`,
   printFile: (id: string) => `print-files/${id}`,
+  mockup: (id: string) => `mockups/${id}`,
 };

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -53,6 +53,14 @@ export async function downloadFile(key: string): Promise<Buffer> {
   });
 }
 
+export async function getPresignedUploadUrl(key: string, contentType: string): Promise<string> {
+  return awsGetSignedUrl(
+    getClient(),
+    new PutObjectCommand({ Bucket: getBucket(), Key: key, ContentType: contentType }),
+    { expiresIn: SIGNED_URL_TTL_SECONDS }
+  );
+}
+
 export async function getSignedUrl(key: string): Promise<string> {
   const client = getClient();
   return awsGetSignedUrl(

--- a/src/test/compositor.test.ts
+++ b/src/test/compositor.test.ts
@@ -39,7 +39,7 @@ describe("compositePrintFile", () => {
       "../lib/compositor"
     );
 
-    await compositePrintFile("designs/test.png", { x: 0, y: 0, scale: 1 });
+    await compositePrintFile("designs/test.png", { x: 0, y: 0, scale: 1, rotate: 0 });
 
     const uploaded: Buffer = mockUploadFile.mock.calls[0][1];
     const meta = await sharp(uploaded).metadata();
@@ -54,7 +54,7 @@ describe("compositePrintFile", () => {
     mockUploadFile.mockResolvedValue(undefined);
 
     const { compositePrintFile } = await import("../lib/compositor");
-    await compositePrintFile("designs/test.png", { x: 0, y: 0, scale: 1 });
+    await compositePrintFile("designs/test.png", { x: 0, y: 0, scale: 1, rotate: 0 });
 
     const uploaded: Buffer = mockUploadFile.mock.calls[0][1];
     const meta = await sharp(uploaded).metadata();
@@ -68,7 +68,7 @@ describe("compositePrintFile", () => {
 
     const { compositePrintFile } = await import("../lib/compositor");
     // scale 0.5 → 100×100 placed at (0,0); pixel at (50,50) should be red
-    await compositePrintFile("designs/test.png", { x: 0, y: 0, scale: 0.5 });
+    await compositePrintFile("designs/test.png", { x: 0, y: 0, scale: 0.5, rotate: 0 });
 
     const uploaded: Buffer = mockUploadFile.mock.calls[0][1];
     const { data } = await sharp(uploaded)
@@ -89,7 +89,7 @@ describe("compositePrintFile", () => {
 
     const { compositePrintFile } = await import("../lib/compositor");
     // place at (500, 600); pixel at (550, 650) should be red
-    await compositePrintFile("designs/test.png", { x: 500, y: 600, scale: 1 });
+    await compositePrintFile("designs/test.png", { x: 500, y: 600, scale: 1, rotate: 0 });
 
     const uploaded: Buffer = mockUploadFile.mock.calls[0][1];
     const { data } = await sharp(uploaded)
@@ -112,6 +112,7 @@ describe("compositePrintFile", () => {
       x: 0,
       y: 0,
       scale: 1,
+      rotate: 0,
     });
 
     expect(key).toMatch(/^print-files\//);
@@ -128,8 +129,24 @@ describe("compositePrintFile", () => {
     mockUploadFile.mockResolvedValue(undefined);
 
     const { compositePrintFile } = await import("../lib/compositor");
-    await compositePrintFile("designs/my-design.png", { x: 0, y: 0, scale: 1 });
+    await compositePrintFile("designs/my-design.png", { x: 0, y: 0, scale: 1, rotate: 0 });
 
     expect(mockDownloadFile).toHaveBeenCalledWith("designs/my-design.png");
+  });
+
+  it("applies rotation — 90° rotate swaps image dimensions before composite", async () => {
+    // 200×100 image rotated 90° becomes 100×200
+    const design = await makePng(200, 100);
+    mockDownloadFile.mockResolvedValue(design);
+    mockUploadFile.mockResolvedValue(undefined);
+
+    const { compositePrintFile } = await import("../lib/compositor");
+    await compositePrintFile("designs/test.png", { x: 0, y: 0, scale: 1, rotate: 90 });
+
+    const uploaded: Buffer = mockUploadFile.mock.calls[0][1];
+    const meta = await sharp(uploaded).metadata();
+    // Canvas is always PRINT_CANVAS size regardless of rotation
+    expect(meta.width).toBe(1800);
+    expect(meta.height).toBe(2400);
   });
 });

--- a/src/test/design-editor.test.tsx
+++ b/src/test/design-editor.test.tsx
@@ -17,6 +17,8 @@ import {
   MIN_PX_H,
   MIN_PX_W,
   PRINT_INCHES_W,
+} from "@/lib/design-constants"
+import {
   computeEffectiveDPI,
   computeInitScale,
   computePrintedWidthIn,

--- a/src/test/mockup.test.ts
+++ b/src/test/mockup.test.ts
@@ -13,7 +13,12 @@ vi.mock("../lib/db", () => ({
 }))
 
 const mockGetSignedUrl = vi.fn()
-vi.mock("../lib/storage", () => ({ getSignedUrl: mockGetSignedUrl }))
+const mockUploadFile = vi.fn()
+vi.mock("../lib/storage", () => ({
+  getSignedUrl: mockGetSignedUrl,
+  uploadFile: mockUploadFile,
+  storageKeys: { mockup: (id: string) => `mockups/${id}` },
+}))
 
 const mockPrintfulGenerateMockup = vi.fn()
 vi.mock("../lib/printful", () => ({ generateMockup: mockPrintfulGenerateMockup }))
@@ -24,11 +29,18 @@ beforeEach(() => {
   mockSet.mockReset()
   mockWhere.mockReset()
   mockGetSignedUrl.mockReset()
+  mockUploadFile.mockReset()
   mockPrintfulGenerateMockup.mockReset()
 
   mockWhere.mockResolvedValue(undefined)
   mockSet.mockReturnValue({ where: mockWhere })
   mockUpdate.mockReturnValue({ set: mockSet })
+  mockUploadFile.mockResolvedValue(undefined)
+
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+    ok: true,
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+  }))
 })
 
 describe("generateMockup", () => {
@@ -39,21 +51,25 @@ describe("generateMockup", () => {
   })
 
   it("throws if printFileKey is missing", async () => {
-    mockFindFirst.mockResolvedValue({ id: "1", printFileKey: null, firstSaleAt: null, mockupUrl: null })
+    mockFindFirst.mockResolvedValue({ id: "1", printFileKey: null, firstSaleAt: null, mockupKey: null })
     const { generateMockup } = await import("../lib/mockup")
     await expect(generateMockup("1")).rejects.toThrow("Drop has no print file")
   })
 
-  it("returns cached mockupUrl after first sale", async () => {
+  it("returns cached signed url after first sale without regenerating", async () => {
     mockFindFirst.mockResolvedValue({
       id: "1",
       printFileKey: "print-files/abc",
       firstSaleAt: new Date(),
-      mockupUrl: "https://cached.example.com/mockup.jpg",
+      mockupKey: "mockups/cached.png",
     })
+    mockGetSignedUrl.mockResolvedValue("https://r2.example.com/mockups/cached.png")
+
     const { generateMockup } = await import("../lib/mockup")
     const url = await generateMockup("1")
-    expect(url).toBe("https://cached.example.com/mockup.jpg")
+
+    expect(url).toBe("https://r2.example.com/mockups/cached.png")
+    expect(mockGetSignedUrl).toHaveBeenCalledWith("mockups/cached.png")
     expect(mockPrintfulGenerateMockup).not.toHaveBeenCalled()
   })
 
@@ -62,9 +78,11 @@ describe("generateMockup", () => {
       id: "1",
       printFileKey: "print-files/abc",
       firstSaleAt: null,
-      mockupUrl: "https://stale.example.com/old.jpg",
+      mockupKey: null,
     })
-    mockGetSignedUrl.mockResolvedValue("https://signed.example.com/print.png")
+    mockGetSignedUrl
+      .mockResolvedValueOnce("https://signed.example.com/print.png")
+      .mockResolvedValueOnce("https://r2.example.com/mockups/new.png")
     mockPrintfulGenerateMockup.mockResolvedValue("https://printful.example.com/new.jpg")
 
     const { generateMockup } = await import("../lib/mockup")
@@ -72,25 +90,27 @@ describe("generateMockup", () => {
 
     expect(mockGetSignedUrl).toHaveBeenCalledWith("print-files/abc")
     expect(mockPrintfulGenerateMockup).toHaveBeenCalledWith("https://signed.example.com/print.png", [4012])
-    expect(url).toBe("https://printful.example.com/new.jpg")
+    expect(mockUploadFile).toHaveBeenCalled()
+    expect(url).toBe("https://r2.example.com/mockups/new.png")
   })
 
-  it("stores returned mockupUrl on the drop record", async () => {
+  it("stores mockupKey on the drop record", async () => {
     mockFindFirst.mockResolvedValue({
       id: "drop-42",
       printFileKey: "print-files/xyz",
       firstSaleAt: null,
-      mockupUrl: null,
+      mockupKey: null,
     })
-    mockGetSignedUrl.mockResolvedValue("https://signed.example.com/print.png")
+    mockGetSignedUrl
+      .mockResolvedValueOnce("https://signed.example.com/print.png")
+      .mockResolvedValueOnce("https://r2.example.com/mockups/new.png")
     mockPrintfulGenerateMockup.mockResolvedValue("https://printful.example.com/mockup.jpg")
 
     const { generateMockup } = await import("../lib/mockup")
     await generateMockup("drop-42")
 
-    expect(mockUpdate).toHaveBeenCalled()
     expect(mockSet).toHaveBeenCalledWith(
-      expect.objectContaining({ mockupUrl: "https://printful.example.com/mockup.jpg" }),
+      expect.objectContaining({ mockupKey: expect.stringMatching(/^mockups\//) }),
     )
   })
 })

--- a/src/test/storage.test.ts
+++ b/src/test/storage.test.ts
@@ -83,6 +83,23 @@ describe("getSignedUrl", () => {
   });
 });
 
+describe("getPresignedUploadUrl", () => {
+  it("returns presigned PUT URL from presigner", async () => {
+    mockGetSignedUrl.mockResolvedValue("https://signed.url/upload-key");
+    const { getPresignedUploadUrl } = await import("../lib/storage");
+
+    const url = await getPresignedUploadUrl("designs/abc.png", "image/png");
+
+    expect(url).toBe("https://signed.url/upload-key");
+    const { PutObjectCommand } = await import("@aws-sdk/client-s3");
+    expect(PutObjectCommand).toHaveBeenCalledWith({
+      Bucket: "test-bucket",
+      Key: "designs/abc.png",
+      ContentType: "image/png",
+    });
+  });
+});
+
 describe("storageKeys", () => {
   it("prefixes design keys correctly", async () => {
     const { storageKeys } = await import("../lib/storage");


### PR DESCRIPTION
Closes #17

## Summary
- Extracts shared UI/print constants + `Placement` type to `design-constants.ts` (no `"use client"`, safe to import server-side)
- Adds `getPresignedUploadUrl` to storage for direct client → R2 PUT uploads
- Adds `rotate` field to `Placement` in schema, drops, and compositor; applies `sharp().rotate()` before resize
- Adds `currentFile` state + `onFileChange` callback to `useDesignEditor` / `DesignEditor`
- Server actions `getDesignUploadUrl` + `runPipeline` with auth/ownership guard and editor→compositor coordinate translation
- `/drops/[id]/design` page + `DesignStep` client state machine: `idle → uploading → processing → preview`

## Test plan
- [x] All 117 existing tests pass (`npm test`)
- [ ] Create drop → redirects to `/drops/[id]/design`
- [ ] Upload PNG → editor opens, place design → "Generate mockup" enabled
- [ ] Click → spinner (uploading) → spinner (processing) → mockup appears
- [ ] "Edit placement" returns to editor; re-submitting re-runs pipeline
- [ ] "Continue →" link renders (points to `/drops/[id]/publish`)
- [ ] Verify `designFileKey`, `printFileKey`, `mockupUrl`, `placement` saved on drop record in DB
- [ ] Drop with `firstSaleAt` shows mockup read-only with locked note

🤖 Generated with [Claude Code](https://claude.com/claude-code)