### PR TITLE
feat: show real buyer total at shipping step

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -109,7 +109,7 @@ BetterAuth magic link flow. User table extended with `slug` (unique creator user
 Creates connected account on "Enable checkout". Generates hosted onboarding link (incremental — `currently_due` only). Polls or webhooks for `charges_enabled` → sets `chargesEnabled: true` on user → transitions drop to `live`. One connected account per creator, reused across all drops.
 
 **Checkout**
-Creates Stripe Checkout session on "Buy now". Direct charge to creator's connected account. Platform application fee = service fee amount (covers 12% platform margin + Stripe processing). Fetches live shipping rates from Printful API and passes as Stripe shipping options. Requires buyer email.
+Creates Stripe Checkout session on "Buy now". Destination charge to creator's connected account via `transfer_data`. Platform sets `application_fee_amount = serviceFee + fulfillmentCents + shippingCents + stripeFee`, which allows the platform to pay Stripe, cover Printful fulfillment and shipping costs, and retain the 12% service fee — while the creator receives exactly their markup. Fetches live shipping rates from Printful API and passes as Stripe shipping options. Session metadata stores `fulfillmentCents` and `shippingCents` for downstream webhook use. Requires buyer email.
 
 **Stripe Webhooks**
 Handles `checkout.session.completed`: captures buyer info, creates order record, submits order to Printful. Handles Printful rejection: issues full refund from connected account, emails buyer and creator. All handlers idempotent.
@@ -151,12 +151,16 @@ BetterAuth user extended with: `slug` (unique), `stripeAccountId`, `chargesEnabl
 ### Pricing Formula
 
 ```
-serviceFee = grossUp(platformMargin + stripeProcessingFee)
-buyerTotal = printfulBase + creatorMarkup + serviceFee
-creatorNets = creatorMarkup (exactly)
+stripeFee       = (buyerTotal + shippingCents) × 2.9% + $0.30
+serviceFee      = buyerTotal × 12%
+applicationFee  = serviceFee + fulfillmentCents + shippingCents + stripeFee
+
+buyerTotal      = ceil((fulfillmentCents + markupCents + shippingCents × 2.9% + $0.30) / (1 − 12% − 2.9%))
+creatorNets     = markupCents (exactly)
+platformNets    = serviceFee + fulfillmentCents + shippingCents (after Stripe deducts its fee from applicationFee)
 ```
 
-Gross-up accounts for Stripe's percentage fee applying to the total charge amount.
+In Stripe destination charges, Stripe deducts its fee from the platform's `application_fee_amount`, not from the connected account. `applicationFee` is therefore set to include the Stripe fee so the platform can pay Stripe and still recover fulfillment + shipping costs. The gross-up formula inflates `buyerTotal` to ensure the creator nets exactly `markupCents` after all deductions. Shipping is added as a separate Stripe line item; the `shippingCents × 2.9%` term in the numerator compensates for Stripe's percentage applying to the combined total.
 
 ### URL Structure
 
@@ -164,7 +168,7 @@ Gross-up accounts for Stripe's percentage fee applying to the total charge amoun
 
 ### Refund Policy
 
-On Printful rejection: platform auto-issues full refund to buyer from creator's connected Stripe account. Stripe processing fee (~$1–2) is non-recoverable and comes out of creator's next payout. Creator is notified by email. Creator agrees to this at publish time via ToS checkbox.
+On Printful rejection: platform auto-issues full refund to buyer from creator's connected Stripe account. The Stripe processing fee is collected by the platform via `application_fee_amount` and is non-recoverable — it is absorbed by the platform, not the creator. Creator is notified by email. Creator agrees to this at publish time via ToS checkbox.
 
 ### Shirt
 

--- a/README.md
+++ b/README.md
@@ -126,3 +126,43 @@ src/
 - **Stripe Connect:** each creator connects once; their account is reused for all drops. Platform takes 12% application fee.
 - **Price lock:** once a drop has its first sale, price and design are locked.
 - **Fulfillment:** `checkout.session.completed` webhook submits the order to Printful. Printful rejection triggers an automatic full refund.
+
+## Money flow
+
+Three parties: **buyer**, **platform** (us), **creator**.
+
+```
+Buyer pays:        buyerTotal (product) + shippingCents (shipping line)
+                   └─ total charge = buyerTotal + shippingCents
+
+Platform collects: applicationFee = serviceFee + fulfillmentCents + shippingCents + stripeFee
+  → pays Stripe:   stripeFee  (~2.9% of total charge + $0.30)
+  → pays Printful: fulfillmentCents + shippingCents  ($12 base + actual shipping)
+  → keeps:         serviceFee  (12% of buyerTotal)
+
+Creator receives:  total charge − applicationFee = markupCents (exactly what they set)
+```
+
+**Gross-up formula** (`src/lib/pricing.ts`): `buyerTotal` is inflated so the creator nets exactly `markupCents` after all deductions. The formula accounts for Stripe's percentage applying to the combined product + shipping total:
+
+```
+buyerTotal = ceil(
+  (fulfillmentCents + markupCents + shippingCents × 2.9% + $0.30)
+  / (1 − 12% − 2.9%)
+)
+```
+
+**Why `applicationFee` includes the Stripe fee:** in Stripe destination charges, Stripe deducts its processing fee from the platform's `application_fee_amount` — not from the connected account. The platform is therefore responsible for the Stripe fee and recoups it through the application fee. The creator's payout is never affected by Stripe fees.
+
+**Concrete example** — $8 markup, $6 shipping:
+
+| | Amount |
+|---|---|
+| Buyer pays (product) | $23.86 |
+| Buyer pays (shipping) | $6.00 |
+| **Buyer total** | **$29.86** |
+| Stripe fee | $1.17 |
+| Fulfillment (Printful) | $18.00 |
+| Service fee (platform) | $2.86 |
+| **Application fee** | **$22.03** |
+| **Creator receives** | **$7.83 ≈ $8.00** |

--- a/drizzle/0002_fat_the_hand.sql
+++ b/drizzle/0002_fat_the_hand.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "order" ADD COLUMN "fulfillment_cents" integer NOT NULL;--> statement-breakpoint
+ALTER TABLE "order" ADD COLUMN "shipping_cents" integer NOT NULL;

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,600 @@
+{
+  "id": "bea0b465-b4a3-4797-8a6b-226a2524f518",
+  "prevId": "fed1907e-45a7-4bc6-b159-f7683b07ef06",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drop": {
+      "name": "drop",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "support_email": {
+          "name": "support_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markup_cents": {
+          "name": "markup_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shirt_color": {
+          "name": "shirt_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'white'"
+        },
+        "status": {
+          "name": "status",
+          "type": "drop_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pre_live'"
+        },
+        "design_file_key": {
+          "name": "design_file_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "print_file_key": {
+          "name": "print_file_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mockup_url": {
+          "name": "mockup_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mockup_key": {
+          "name": "mockup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placement": {
+          "name": "placement",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_sale_at": {
+          "name": "first_sale_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drop_user_id_slug_unique": {
+          "name": "drop_user_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "drop_id": {
+          "name": "drop_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_session_id": {
+          "name": "stripe_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "printful_order_id": {
+          "name": "printful_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "size": {
+          "name": "size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipping_address": {
+          "name": "shipping_address",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buyer_email": {
+          "name": "buyer_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_cents": {
+          "name": "total_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markup_cents": {
+          "name": "markup_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fulfillment_cents": {
+          "name": "fulfillment_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipping_cents": {
+          "name": "shipping_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_stripe_session_id_unique": {
+          "name": "order_stripe_session_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_session_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "charges_enabled": {
+          "name": "charges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_slug_unique": {
+          "name": "user_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.drop_status": {
+      "name": "drop_status",
+      "schema": "public",
+      "values": [
+        "pre_live",
+        "live",
+        "paused",
+        "closed"
+      ]
+    },
+    "public.order_status": {
+      "name": "order_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "paid",
+        "submitted",
+        "shipped",
+        "cancelled"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1777465191455,
       "tag": "0001_salty_vulcan",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1777538359128,
+      "tag": "0002_fat_the_hand",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/[creatorSlug]/[dropSlug]/page.tsx
+++ b/src/app/[creatorSlug]/[dropSlug]/page.tsx
@@ -67,7 +67,7 @@ export default async function PublicDropPage({ params }: Props) {
   }
 
   const { buyerTotal } = calculatePrice(BASE_SHIRT_COST_CENTS, drop.markupCents)
-  const priceDisplay = `$${(buyerTotal / 100).toFixed(2)}`
+  const priceDisplay = `from $${(buyerTotal / 100).toFixed(2)} + shipping`
 
   return (
     <main className="flex min-h-screen items-center justify-center p-8">
@@ -99,7 +99,7 @@ export default async function PublicDropPage({ params }: Props) {
               <p className="text-2xl font-medium">{priceDisplay}</p>
             </div>
 
-            <BuyForm dropId={drop.id} priceDisplay={priceDisplay} />
+            <BuyForm dropId={drop.id} priceDisplay={priceDisplay} markupCents={drop.markupCents} />
 
             <div className="space-y-1 text-sm text-muted-foreground">
               <p>Printed &amp; shipped in 3–5 business days.</p>

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -59,14 +59,13 @@ export async function POST(request: Request) {
 
   const FULFILLMENT_MIN_CENTS = 800
   const FULFILLMENT_MAX_CENTS = 5000
-  const safeFulfillmentCents = Math.min(
-    Math.max(clientFulfillmentCents, FULFILLMENT_MIN_CENTS),
-    FULFILLMENT_MAX_CENTS,
-  )
+  if (clientFulfillmentCents < FULFILLMENT_MIN_CENTS || clientFulfillmentCents > FULFILLMENT_MAX_CENTS) {
+    return NextResponse.json({ error: "Invalid fulfillment cost" }, { status: 400 })
+  }
 
   const shippingAmountCents = Math.round(parseFloat(selectedRate.rate) * 100)
   const { buyerTotal, applicationFee, fulfillmentCents } = calculatePrice(
-    safeFulfillmentCents,
+    clientFulfillmentCents,
     record.markupCents,
     shippingAmountCents,
   )

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -56,8 +56,12 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Drop not available" }, { status: 404 })
   }
 
-  const { buyerTotal, serviceFee } = calculatePrice(BASE_SHIRT_COST_CENTS, record.markupCents)
   const shippingAmountCents = Math.round(parseFloat(selectedRate.rate) * 100)
+  const { buyerTotal, applicationFee, fulfillmentCents } = calculatePrice(
+    BASE_SHIRT_COST_CENTS,
+    record.markupCents,
+    shippingAmountCents
+  )
 
   const baseUrl = process.env.NEXT_PUBLIC_URL ?? "http://localhost:3000"
   const creatorSlug = creator.slug ?? creator.id
@@ -101,7 +105,7 @@ export async function POST(request: Request) {
     ],
     shipping_options: shippingRateData,
     payment_intent_data: {
-      application_fee_amount: serviceFee,
+      application_fee_amount: applicationFee,
       on_behalf_of: creator.stripeAccountId,
       transfer_data: { destination: creator.stripeAccountId },
     },
@@ -112,6 +116,8 @@ export async function POST(request: Request) {
       address: JSON.stringify(address),
       shippingRateId: selectedRate.id,
       shippingName: selectedRate.name,
+      fulfillmentCents: String(fulfillmentCents),
+      shippingCents: String(shippingAmountCents),
     },
     success_url: `${dropUrl}/success?session_id={CHECKOUT_SESSION_ID}`,
     cancel_url: dropUrl,

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -4,7 +4,7 @@ import { eq } from "drizzle-orm"
 import { db } from "@/lib/db"
 import { drop, user } from "@/lib/db/schema"
 import { stripe } from "@/lib/stripe"
-import { calculatePrice, BASE_SHIRT_COST_CENTS } from "@/lib/pricing"
+import { calculatePrice } from "@/lib/pricing"
 
 const addressSchema = z.object({
   name: z.string().min(1),
@@ -29,6 +29,7 @@ const bodySchema = z.object({
   size: z.enum(["S", "M", "L", "XL", "2XL"]),
   address: addressSchema,
   selectedRate: selectedRateSchema,
+  fulfillmentCents: z.number().int(),
 })
 
 export async function POST(request: Request) {
@@ -44,7 +45,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Invalid request" }, { status: 400 })
   }
 
-  const { dropId, size, address, selectedRate } = parsed.data
+  const { dropId, size, address, selectedRate, fulfillmentCents: clientFulfillmentCents } = parsed.data
 
   const record = await db.query.drop.findFirst({ where: eq(drop.id, dropId) })
   if (!record || record.status !== "live") {
@@ -56,11 +57,18 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Drop not available" }, { status: 404 })
   }
 
+  const FULFILLMENT_MIN_CENTS = 800
+  const FULFILLMENT_MAX_CENTS = 5000
+  const safeFulfillmentCents = Math.min(
+    Math.max(clientFulfillmentCents, FULFILLMENT_MIN_CENTS),
+    FULFILLMENT_MAX_CENTS,
+  )
+
   const shippingAmountCents = Math.round(parseFloat(selectedRate.rate) * 100)
   const { buyerTotal, applicationFee, fulfillmentCents } = calculatePrice(
-    BASE_SHIRT_COST_CENTS,
+    safeFulfillmentCents,
     record.markupCents,
-    shippingAmountCents
+    shippingAmountCents,
   )
 
   const baseUrl = process.env.NEXT_PUBLIC_URL ?? "http://localhost:3000"

--- a/src/app/api/shipping-rates/route.ts
+++ b/src/app/api/shipping-rates/route.ts
@@ -3,7 +3,7 @@ import { z } from "zod"
 import { eq } from "drizzle-orm"
 import { db } from "@/lib/db"
 import { drop } from "@/lib/db/schema"
-import { getShippingRates, PrintfulError } from "@/lib/printful"
+import { getShippingRates, estimateOrderCost, PrintfulError } from "@/lib/printful"
 import { BC3001_VARIANTS } from "@/lib/variants"
 
 const bodySchema = z.object({
@@ -44,18 +44,21 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Invalid size" }, { status: 400 })
   }
 
+  const printfulAddress = {
+    address1: address.address1,
+    city: address.city,
+    stateCode: address.stateCode,
+    countryCode: address.countryCode,
+    zip: address.zip,
+  }
+  const printfulItems = [{ variantId, quantity: 1 }]
+
   try {
-    const rates = await getShippingRates(
-      {
-        address1: address.address1,
-        city: address.city,
-        stateCode: address.stateCode,
-        countryCode: address.countryCode,
-        zip: address.zip,
-      },
-      [{ variantId, quantity: 1 }],
-    )
-    return NextResponse.json({ rates })
+    const [rates, fulfillmentCents] = await Promise.all([
+      getShippingRates(printfulAddress, printfulItems),
+      estimateOrderCost(printfulAddress, printfulItems),
+    ])
+    return NextResponse.json({ rates, fulfillmentCents })
   } catch (err) {
     const message =
       err instanceof PrintfulError ? "Check your address and try again." : "Failed to fetch shipping rates."

--- a/src/app/api/shipping-rates/route.ts
+++ b/src/app/api/shipping-rates/route.ts
@@ -5,6 +5,8 @@ import { db } from "@/lib/db"
 import { drop } from "@/lib/db/schema"
 import { getShippingRates, estimateOrderCost, PrintfulError } from "@/lib/printful"
 import { BC3001_VARIANTS } from "@/lib/variants"
+import { getSignedUrl } from "@/lib/storage"
+import { BASE_SHIRT_COST_CENTS } from "@/lib/pricing"
 
 const bodySchema = z.object({
   dropId: z.string().uuid(),
@@ -38,6 +40,10 @@ export async function POST(request: Request) {
   if (!record || record.status !== "live") {
     return NextResponse.json({ error: "Drop not available" }, { status: 404 })
   }
+  if (!record.printFileKey) {
+    return NextResponse.json({ error: "Drop not available" }, { status: 404 })
+  }
+  const printFileUrl = await getSignedUrl(record.printFileKey)
 
   const variantId = BC3001_VARIANTS[size]
   if (!variantId) {
@@ -53,15 +59,30 @@ export async function POST(request: Request) {
   }
   const printfulItems = [{ variantId, quantity: 1 }]
 
+  let rates: Awaited<ReturnType<typeof getShippingRates>>
   try {
-    const [rates, fulfillmentCents] = await Promise.all([
-      getShippingRates(printfulAddress, printfulItems),
-      estimateOrderCost(printfulAddress, printfulItems),
-    ])
-    return NextResponse.json({ rates, fulfillmentCents })
+    rates = await getShippingRates(printfulAddress, printfulItems)
   } catch (err) {
-    const message =
-      err instanceof PrintfulError ? "Check your address and try again." : "Failed to fetch shipping rates."
+    if (err instanceof PrintfulError) {
+      console.error("[shipping-rates] getShippingRates failed", { code: err.code, reason: err.reason, message: err.message })
+    } else {
+      console.error("[shipping-rates] getShippingRates unexpected error", err)
+    }
+    const message = err instanceof PrintfulError ? "Check your address and try again." : "Failed to fetch shipping rates."
     return NextResponse.json({ error: message }, { status: 422 })
   }
+
+  let fulfillmentCents: number
+  try {
+    fulfillmentCents = await estimateOrderCost(printfulAddress, printfulItems, printFileUrl)
+  } catch (err) {
+    if (err instanceof PrintfulError) {
+      console.error("[shipping-rates] estimateOrderCost failed, falling back to base cost", { code: err.code, reason: err.reason, message: err.message })
+    } else {
+      console.error("[shipping-rates] estimateOrderCost unexpected error, falling back to base cost", err)
+    }
+    fulfillmentCents = BASE_SHIRT_COST_CENTS
+  }
+
+  return NextResponse.json({ rates, fulfillmentCents })
 }

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -57,7 +57,7 @@ async function handleAccountUpdated(account: Stripe.Account) {
 }
 
 async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
-  const { dropId, size, address: addressJson, buyerName } = session.metadata ?? {}
+  const { dropId, size, address: addressJson, buyerName, fulfillmentCents, shippingCents } = session.metadata ?? {}
   if (!dropId || !size || !addressJson) return
 
   const buyerEmail = session.customer_details?.email ?? ""
@@ -92,6 +92,8 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
       buyerEmail,
       totalCents,
       markupCents: record.markupCents,
+      fulfillmentCents: Number(fulfillmentCents ?? 0),
+      shippingCents: Number(shippingCents ?? 0),
     })
     .returning()
 

--- a/src/components/drops/buy-form.tsx
+++ b/src/components/drops/buy-form.tsx
@@ -46,6 +46,7 @@ export function BuyForm({ dropId, priceDisplay }: BuyFormProps) {
   })
   const [rates, setRates] = useState<ShippingRate[]>([])
   const [selectedRateId, setSelectedRateId] = useState<string | null>(null)
+  const [fulfillmentCents, setFulfillmentCents] = useState<number | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -63,8 +64,12 @@ export function BuyForm({ dropId, priceDisplay }: BuyFormProps) {
     })
     setLoading(false)
     if (res.ok) {
-      const { rates: fetched } = (await res.json()) as { rates: ShippingRate[] }
+      const { rates: fetched, fulfillmentCents: cost } = (await res.json()) as {
+        rates: ShippingRate[]
+        fulfillmentCents: number
+      }
       setRates(fetched)
+      setFulfillmentCents(cost)
       setSelectedRateId(fetched[0]?.id ?? null)
       setStep("shipping")
     } else {
@@ -82,7 +87,7 @@ export function BuyForm({ dropId, priceDisplay }: BuyFormProps) {
     const res = await fetch("/api/checkout", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ dropId, size, address, selectedRate }),
+      body: JSON.stringify({ dropId, size, address, selectedRate, fulfillmentCents }),
     })
     if (res.ok) {
       const { url } = (await res.json()) as { url: string }

--- a/src/components/drops/buy-form.tsx
+++ b/src/components/drops/buy-form.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { calculatePrice } from "@/lib/pricing"
 
 const SIZES = ["S", "M", "L", "XL", "2XL"] as const
 type Size = (typeof SIZES)[number]
@@ -31,9 +32,10 @@ interface ShippingRate {
 interface BuyFormProps {
   dropId: string
   priceDisplay: string
+  markupCents: number
 }
 
-export function BuyForm({ dropId, priceDisplay }: BuyFormProps) {
+export function BuyForm({ dropId, priceDisplay, markupCents }: BuyFormProps) {
   const [step, setStep] = useState<Step>("size")
   const [size, setSize] = useState<Size | null>(null)
   const [address, setAddress] = useState<Address>({
@@ -205,9 +207,17 @@ export function BuyForm({ dropId, priceDisplay }: BuyFormProps) {
   // step === "shipping"
   const selectedRate = rates.find((r) => r.id === selectedRateId)
 
+  const baseGrandTotal =
+    fulfillmentCents !== null ? calculatePrice(fulfillmentCents, markupCents, 0).grandTotal : null
+
   function formatRate(rate: ShippingRate) {
-    const cents = Math.round(parseFloat(rate.rate) * 100)
-    const price = cents === 0 ? "Free" : `$${(cents / 100).toFixed(2)}`
+    const rawCents = Math.round(parseFloat(rate.rate) * 100)
+    let effectiveCents = rawCents
+    if (fulfillmentCents !== null && baseGrandTotal !== null) {
+      const { grandTotal } = calculatePrice(fulfillmentCents, markupCents, rawCents)
+      effectiveCents = grandTotal - baseGrandTotal
+    }
+    const price = effectiveCents === 0 ? "Free" : `$${(effectiveCents / 100).toFixed(2)}`
     const days =
       rate.minDeliveryDays != null
         ? ` · ${rate.minDeliveryDays}–${rate.maxDeliveryDays ?? rate.minDeliveryDays} days`
@@ -215,9 +225,12 @@ export function BuyForm({ dropId, priceDisplay }: BuyFormProps) {
     return { price, days }
   }
 
-  const shippingDisplay = selectedRate
-    ? ` + $${(Math.round(parseFloat(selectedRate.rate) * 100) / 100).toFixed(2)} shipping`
-    : ""
+  const buyerTotalDisplay = (() => {
+    if (!selectedRate || fulfillmentCents === null) return priceDisplay
+    const shippingCents = Math.round(parseFloat(selectedRate.rate) * 100)
+    const { grandTotal } = calculatePrice(fulfillmentCents, markupCents, shippingCents)
+    return `$${(grandTotal / 100).toFixed(2)}`
+  })()
 
   return (
     <div className="flex flex-col gap-4">
@@ -257,7 +270,7 @@ export function BuyForm({ dropId, priceDisplay }: BuyFormProps) {
           Back
         </Button>
         <Button disabled={!selectedRateId || loading} onClick={handleBuy} className="flex-1">
-          {loading ? "Redirecting…" : `Buy — ${priceDisplay}${shippingDisplay}`}
+          {loading ? "Redirecting…" : `Buy — ${buyerTotalDisplay}`}
         </Button>
       </div>
     </div>

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -60,6 +60,8 @@ export const order = pgTable("order", {
   buyerEmail: text("buyer_email").notNull(),
   totalCents: integer("total_cents").notNull(),
   markupCents: integer("markup_cents").notNull(),
+  fulfillmentCents: integer("fulfillment_cents").notNull(),
+  shippingCents: integer("shipping_cents").notNull(),
   createdAt: timestamp("created_at").notNull().defaultNow(),
 });
 

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -6,7 +6,10 @@ const STRIPE_PERCENT = 0.029;
 const STRIPE_FIXED_CENTS = 30;
 
 export interface PriceBreakdown {
+  /** Stripe line item amount (excludes shipping, which Stripe adds separately) */
   buyerTotal: number;
+  /** Total the buyer pays: buyerTotal + shippingCents */
+  grandTotal: number;
   serviceFee: number;
   applicationFee: number;
   fulfillmentCents: number;
@@ -34,5 +37,5 @@ export function calculatePrice(
   const applicationFee = serviceFee + baseCents + shippingCents + stripeFee;
   const creatorNet = totalCharge - applicationFee;
 
-  return { buyerTotal, serviceFee, applicationFee, fulfillmentCents: baseCents, creatorNet };
+  return { buyerTotal, grandTotal: totalCharge, serviceFee, applicationFee, fulfillmentCents: baseCents, creatorNet };
 }

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -8,25 +8,31 @@ const STRIPE_FIXED_CENTS = 30;
 export interface PriceBreakdown {
   buyerTotal: number;
   serviceFee: number;
+  applicationFee: number;
+  fulfillmentCents: number;
   creatorNet: number;
 }
 
 /**
- * Gross-up formula: total = (base + markup + fixed) / (1 - platform% - stripe%)
- * Ensures creator nets markupCents exactly after Stripe and platform fees.
+ * Gross-up formula accounting for shipping in Stripe fee base.
+ * applicationFee = serviceFee + fulfillmentCents + shippingCents — platform collects
+ * fulfillment and shipping so creator nets exactly markupCents.
  */
 export function calculatePrice(
   baseCents: number,
-  markupCents: number
+  markupCents: number,
+  shippingCents: number = 0
 ): PriceBreakdown {
-  const subtotal = baseCents + markupCents;
   const buyerTotal = Math.ceil(
-    (subtotal + STRIPE_FIXED_CENTS) / (1 - PLATFORM_FEE_RATE - STRIPE_PERCENT)
+    (baseCents + markupCents + shippingCents * STRIPE_PERCENT + STRIPE_FIXED_CENTS) /
+      (1 - PLATFORM_FEE_RATE - STRIPE_PERCENT)
   );
 
-  const stripeFee = Math.round(buyerTotal * STRIPE_PERCENT + STRIPE_FIXED_CENTS);
+  const totalCharge = buyerTotal + shippingCents;
+  const stripeFee = Math.round(totalCharge * STRIPE_PERCENT + STRIPE_FIXED_CENTS);
   const serviceFee = Math.round(buyerTotal * PLATFORM_FEE_RATE);
-  const creatorNet = buyerTotal - stripeFee - serviceFee - baseCents;
+  const applicationFee = serviceFee + baseCents + shippingCents + stripeFee;
+  const creatorNet = totalCharge - applicationFee;
 
-  return { buyerTotal, serviceFee, creatorNet };
+  return { buyerTotal, serviceFee, applicationFee, fulfillmentCents: baseCents, creatorNet };
 }

--- a/src/lib/printful.ts
+++ b/src/lib/printful.ts
@@ -207,6 +207,41 @@ export async function generateMockup(
   throw new PrintfulError(0, "timeout", "Mockup generation timed out after 60s")
 }
 
+// ─── Order estimate ───────────────────────────────────────────────────────────
+
+const orderEstimateSchema = z.looseObject({
+  costs: z.looseObject({
+    subtotal: z.string(),
+    vat: z.string(),
+  }),
+})
+
+export async function estimateOrderCost(
+  address: ShippingAddress,
+  items: ShippingItem[],
+): Promise<number> {
+  const result = await request(
+    "/orders/estimate",
+    orderEstimateSchema,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        recipient: {
+          address1: address.address1,
+          city: address.city,
+          state_code: address.stateCode,
+          country_code: address.countryCode,
+          zip: address.zip,
+        },
+        items: items.map((i) => ({ variant_id: i.variantId, quantity: i.quantity })),
+      }),
+    },
+  )
+  const subtotalCents = Math.round(parseFloat(result.costs.subtotal) * 100)
+  const vatCents = Math.round(parseFloat(result.costs.vat) * 100)
+  return subtotalCents + vatCents
+}
+
 // ─── Shipping rates ───────────────────────────────────────────────────────────
 
 const shippingRateSchema = z.looseObject({

--- a/src/lib/printful.ts
+++ b/src/lib/printful.ts
@@ -219,21 +219,27 @@ const orderEstimateSchema = z.looseObject({
 export async function estimateOrderCost(
   address: ShippingAddress,
   items: ShippingItem[],
+  printFileUrl: string,
 ): Promise<number> {
   const result = await request(
-    "/orders/estimate",
+    "/orders/estimate-costs",
     orderEstimateSchema,
     {
       method: "POST",
       body: JSON.stringify({
         recipient: {
+          name: "Customer",
           address1: address.address1,
           city: address.city,
           state_code: address.stateCode,
           country_code: address.countryCode,
           zip: address.zip,
         },
-        items: items.map((i) => ({ variant_id: i.variantId, quantity: i.quantity })),
+        items: items.map((i) => ({
+          variant_id: i.variantId,
+          quantity: i.quantity,
+          files: [{ url: printFileUrl }],
+        })),
       }),
     },
   )

--- a/src/test/buy-form.test.tsx
+++ b/src/test/buy-form.test.tsx
@@ -14,6 +14,29 @@ async function renderForm(priceDisplay = "$28.50") {
   render(<BuyForm dropId="drop-1" priceDisplay={priceDisplay} />)
 }
 
+const SHIPPING_RATES_RESPONSE = {
+  rates: [{ id: "STANDARD", name: "Standard", rate: "5.99", currency: "USD", minDeliveryDays: 3, maxDeliveryDays: 5 }],
+  fulfillmentCents: 1350,
+}
+
+async function goToShippingStep() {
+  vi.mocked(global.fetch).mockResolvedValueOnce(
+    new Response(JSON.stringify(SHIPPING_RATES_RESPONSE), { status: 200 }),
+  )
+
+  await userEvent.click(screen.getByRole("button", { name: "L" }))
+  await userEvent.click(screen.getByRole("button", { name: /continue/i }))
+
+  await userEvent.type(screen.getByLabelText("Full name"), "Jane Doe")
+  await userEvent.type(screen.getByLabelText("Address"), "1 Main St")
+  await userEvent.type(screen.getByLabelText("City"), "Portland")
+  await userEvent.type(screen.getByLabelText("ZIP / Postal"), "97201")
+  await userEvent.type(screen.getByLabelText("Country code"), "US")
+
+  await userEvent.click(screen.getByRole("button", { name: /get shipping rates/i }))
+  await screen.findByText(/standard/i)
+}
+
 // ─── Rendering ────────────────────────────────────────────────────────────────
 
 describe("BuyForm rendering", () => {
@@ -24,65 +47,121 @@ describe("BuyForm rendering", () => {
     }
   })
 
-  it("renders buy button with price", async () => {
+  it("renders continue button with price on size step", async () => {
     await renderForm("$28.50")
-    expect(screen.getByRole("button", { name: /buy.*\$28\.50/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /continue.*\$28\.50/i })).toBeInTheDocument()
   })
 
-  it("buy button is disabled before size is selected", async () => {
+  it("continue button is disabled before size is selected", async () => {
     await renderForm()
-    expect(screen.getByRole("button", { name: /buy/i })).toBeDisabled()
+    expect(screen.getByRole("button", { name: /continue/i })).toBeDisabled()
   })
 })
 
 // ─── Size selection ───────────────────────────────────────────────────────────
 
 describe("size selection", () => {
-  it("enables buy button after selecting a size", async () => {
+  it("enables continue button after selecting a size", async () => {
     await renderForm()
     await userEvent.click(screen.getByRole("button", { name: "M" }))
-    expect(screen.getByRole("button", { name: /buy/i })).not.toBeDisabled()
+    expect(screen.getByRole("button", { name: /continue/i })).not.toBeDisabled()
   })
 
   it("can switch between sizes", async () => {
     await renderForm()
     await userEvent.click(screen.getByRole("button", { name: "M" }))
     await userEvent.click(screen.getByRole("button", { name: "XL" }))
-    expect(screen.getByRole("button", { name: /buy/i })).not.toBeDisabled()
+    expect(screen.getByRole("button", { name: /continue/i })).not.toBeDisabled()
+  })
+})
+
+// ─── Address step ─────────────────────────────────────────────────────────────
+
+describe("address step", () => {
+  it("advances to address step after selecting a size and clicking continue", async () => {
+    await renderForm()
+    await userEvent.click(screen.getByRole("button", { name: "M" }))
+    await userEvent.click(screen.getByRole("button", { name: /continue/i }))
+    expect(screen.getByLabelText("Full name")).toBeInTheDocument()
+  })
+
+  it("get shipping rates button is disabled until required fields are filled", async () => {
+    await renderForm()
+    await userEvent.click(screen.getByRole("button", { name: "M" }))
+    await userEvent.click(screen.getByRole("button", { name: /continue/i }))
+    expect(screen.getByRole("button", { name: /get shipping rates/i })).toBeDisabled()
+  })
+})
+
+// ─── Shipping step ────────────────────────────────────────────────────────────
+
+describe("shipping step", () => {
+  it("shows shipping rates after address is submitted", async () => {
+    await renderForm()
+    await goToShippingStep()
+    expect(screen.getByText(/standard/i)).toBeInTheDocument()
+  })
+
+  it("calls /api/shipping-rates with address and size", async () => {
+    await renderForm()
+    await goToShippingStep()
+
+    const [url, init] = vi.mocked(global.fetch).mock.calls[0] as [string, RequestInit]
+    expect(url).toBe("/api/shipping-rates")
+    const body = JSON.parse(init.body as string)
+    expect(body.size).toBe("L")
+    expect(body.address.name).toBe("Jane Doe")
+  })
+
+  it("shows error message when shipping rates fetch fails", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "Check your address and try again." }), { status: 422 }),
+    )
+
+    await renderForm()
+    await userEvent.click(screen.getByRole("button", { name: "L" }))
+    await userEvent.click(screen.getByRole("button", { name: /continue/i }))
+    await userEvent.type(screen.getByLabelText("Full name"), "Jane Doe")
+    await userEvent.type(screen.getByLabelText("Address"), "1 Main St")
+    await userEvent.type(screen.getByLabelText("City"), "Portland")
+    await userEvent.type(screen.getByLabelText("ZIP / Postal"), "97201")
+    await userEvent.type(screen.getByLabelText("Country code"), "US")
+    await userEvent.click(screen.getByRole("button", { name: /get shipping rates/i }))
+
+    await screen.findByText("Check your address and try again.")
   })
 })
 
 // ─── Checkout submission ──────────────────────────────────────────────────────
 
 describe("checkout submission", () => {
-  it("POSTs dropId and selected size to /api/checkout", async () => {
-    vi.mocked(global.fetch).mockResolvedValue(
-      new Response(JSON.stringify({ url: "https://checkout.stripe.com/session" }), { status: 200 })
+  it("POSTs fulfillmentCents from shipping-rates response to /api/checkout", async () => {
+    await renderForm()
+    await goToShippingStep()
+
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ url: "https://checkout.stripe.com/session" }), { status: 200 }),
     )
 
-    await renderForm()
-    await userEvent.click(screen.getByRole("button", { name: "L" }))
     await userEvent.click(screen.getByRole("button", { name: /buy/i }))
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith(
-        "/api/checkout",
-        expect.objectContaining({ method: "POST" })
-      )
+      const checkoutCall = vi.mocked(global.fetch).mock.calls[1] as [string, RequestInit]
+      expect(checkoutCall[0]).toBe("/api/checkout")
+      const body = JSON.parse(checkoutCall[1].body as string)
+      expect(body.fulfillmentCents).toBe(1350)
+      expect(body.size).toBe("L")
+      expect(body.selectedRate.id).toBe("STANDARD")
     })
-
-    const body = JSON.parse(
-      (vi.mocked(global.fetch).mock.calls[0][1] as RequestInit).body as string
-    )
-    expect(body).toEqual({ dropId: "drop-1", size: "L" })
   })
 
-  it("shows Redirecting… while awaiting response", async () => {
-    let resolve!: (v: Response) => void
-    vi.mocked(global.fetch).mockReturnValue(new Promise((r) => (resolve = r)))
-
+  it("shows Redirecting… while awaiting checkout response", async () => {
     await renderForm()
-    await userEvent.click(screen.getByRole("button", { name: "S" }))
+    await goToShippingStep()
+
+    let resolve!: (v: Response) => void
+    vi.mocked(global.fetch).mockReturnValueOnce(new Promise((r) => (resolve = r)))
+
     await userEvent.click(screen.getByRole("button", { name: /buy/i }))
 
     expect(await screen.findByRole("button", { name: /redirecting/i })).toBeInTheDocument()
@@ -90,13 +169,14 @@ describe("checkout submission", () => {
     resolve(new Response(JSON.stringify({ url: "https://checkout.stripe.com/s" }), { status: 200 }))
   })
 
-  it("re-enables buy button if checkout request fails", async () => {
-    vi.mocked(global.fetch).mockResolvedValue(
-      new Response(JSON.stringify({ error: "failed" }), { status: 500 })
+  it("shows error and re-enables buy button if checkout fails", async () => {
+    await renderForm()
+    await goToShippingStep()
+
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "failed" }), { status: 500 }),
     )
 
-    await renderForm()
-    await userEvent.click(screen.getByRole("button", { name: "M" }))
     await userEvent.click(screen.getByRole("button", { name: /buy/i }))
 
     await waitFor(() => {

--- a/src/test/buy-form.test.tsx
+++ b/src/test/buy-form.test.tsx
@@ -9,9 +9,9 @@ beforeEach(() => {
 
 afterEach(cleanup)
 
-async function renderForm(priceDisplay = "$28.50") {
+async function renderForm(priceDisplay = "from $28.50", markupCents = 1500) {
   const { BuyForm } = await import("@/components/drops/buy-form")
-  render(<BuyForm dropId="drop-1" priceDisplay={priceDisplay} />)
+  render(<BuyForm dropId="drop-1" priceDisplay={priceDisplay} markupCents={markupCents} />)
 }
 
 const SHIPPING_RATES_RESPONSE = {
@@ -48,8 +48,8 @@ describe("BuyForm rendering", () => {
   })
 
   it("renders continue button with price on size step", async () => {
-    await renderForm("$28.50")
-    expect(screen.getByRole("button", { name: /continue.*\$28\.50/i })).toBeInTheDocument()
+    await renderForm("from $28.50 + shipping")
+    expect(screen.getByRole("button", { name: /continue.*from \$28\.50 \+ shipping/i })).toBeInTheDocument()
   })
 
   it("continue button is disabled before size is selected", async () => {

--- a/src/test/checkout.test.ts
+++ b/src/test/checkout.test.ts
@@ -143,17 +143,19 @@ describe("POST /api/checkout", () => {
     })
   })
 
-  describe("fulfillmentCents clamping", () => {
-    it("clamps fulfillmentCents below min (800) up to 800", async () => {
+  describe("fulfillmentCents validation", () => {
+    it("rejects fulfillmentCents below min (800) with 400", async () => {
       const { POST } = await import("@/app/api/checkout/route")
-      await POST(makeRequest(validBody({ fulfillmentCents: 100 })))
-      expect(mockCalculatePrice).toHaveBeenCalledWith(800, DROP.markupCents, expect.any(Number))
+      const res = await POST(makeRequest(validBody({ fulfillmentCents: 100 })))
+      expect(res.status).toBe(400)
+      expect(mockCalculatePrice).not.toHaveBeenCalled()
     })
 
-    it("clamps fulfillmentCents above max (5000) down to 5000", async () => {
+    it("rejects fulfillmentCents above max (5000) with 400", async () => {
       const { POST } = await import("@/app/api/checkout/route")
-      await POST(makeRequest(validBody({ fulfillmentCents: 9999 })))
-      expect(mockCalculatePrice).toHaveBeenCalledWith(5000, DROP.markupCents, expect.any(Number))
+      const res = await POST(makeRequest(validBody({ fulfillmentCents: 9999 })))
+      expect(res.status).toBe(400)
+      expect(mockCalculatePrice).not.toHaveBeenCalled()
     })
 
     it("passes fulfillmentCents unchanged when within valid range", async () => {

--- a/src/test/checkout.test.ts
+++ b/src/test/checkout.test.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockFindFirstDrop = vi.fn()
+const mockFindFirstUser = vi.fn()
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    query: {
+      drop: { findFirst: mockFindFirstDrop },
+      user: { findFirst: mockFindFirstUser },
+    },
+  },
+}))
+
+vi.mock("@/lib/db/schema", () => ({
+  drop: "drop-table",
+  user: "user-table",
+}))
+
+const mockSessionsCreate = vi.fn()
+vi.mock("@/lib/stripe", () => ({
+  stripe: { checkout: { sessions: { create: mockSessionsCreate } } },
+}))
+
+const mockCalculatePrice = vi.fn()
+vi.mock("@/lib/pricing", () => ({
+  calculatePrice: mockCalculatePrice,
+}))
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const DROP_ID = "123e4567-e89b-12d3-a456-426614174000"
+
+const DROP = {
+  id: DROP_ID,
+  userId: "user-1",
+  title: "Test Drop",
+  markupCents: 1000,
+  status: "live",
+  slug: "test-drop",
+}
+
+const CREATOR = {
+  id: "user-1",
+  slug: "creator",
+  stripeAccountId: "acct_test",
+  chargesEnabled: true,
+}
+
+const ADDRESS = {
+  name: "Jane Doe",
+  address1: "1 Main St",
+  city: "Portland",
+  stateCode: "OR",
+  zip: "97201",
+  countryCode: "US",
+}
+
+const SELECTED_RATE = {
+  id: "STANDARD",
+  name: "Standard",
+  rate: "5.99",
+  currency: "USD",
+  minDeliveryDays: 3,
+  maxDeliveryDays: 5,
+}
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request("http://localhost/api/checkout", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  })
+}
+
+function validBody(overrides?: Record<string, unknown>) {
+  return {
+    dropId: DROP_ID,
+    size: "M",
+    address: ADDRESS,
+    selectedRate: SELECTED_RATE,
+    fulfillmentCents: 1350,
+    ...overrides,
+  }
+}
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  process.env.NEXT_PUBLIC_URL = "http://localhost:3000"
+
+  mockFindFirstDrop.mockResolvedValue(DROP)
+  mockFindFirstUser.mockResolvedValue(CREATOR)
+  mockCalculatePrice.mockReturnValue({
+    buyerTotal: 2800,
+    applicationFee: 500,
+    fulfillmentCents: 1350,
+    serviceFee: 200,
+    creatorNet: 1000,
+  })
+  mockSessionsCreate.mockResolvedValue({ url: "https://checkout.stripe.com/session" })
+})
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("POST /api/checkout", () => {
+  describe("validation", () => {
+    it("returns 400 when fulfillmentCents is missing", async () => {
+      const { POST } = await import("@/app/api/checkout/route")
+      const body = validBody()
+      delete (body as Record<string, unknown>).fulfillmentCents
+      const res = await POST(makeRequest(body))
+      expect(res.status).toBe(400)
+    })
+
+    it("returns 400 when fulfillmentCents is not an integer", async () => {
+      const { POST } = await import("@/app/api/checkout/route")
+      const res = await POST(makeRequest(validBody({ fulfillmentCents: "not-a-number" })))
+      expect(res.status).toBe(400)
+    })
+
+    it("returns 400 when fulfillmentCents is a float", async () => {
+      const { POST } = await import("@/app/api/checkout/route")
+      const res = await POST(makeRequest(validBody({ fulfillmentCents: 13.5 })))
+      expect(res.status).toBe(400)
+    })
+
+    it("returns 404 when drop not found", async () => {
+      mockFindFirstDrop.mockResolvedValue(null)
+      const { POST } = await import("@/app/api/checkout/route")
+      const res = await POST(makeRequest(validBody()))
+      expect(res.status).toBe(404)
+    })
+
+    it("returns 404 when drop is not live", async () => {
+      mockFindFirstDrop.mockResolvedValue({ ...DROP, status: "paused" })
+      const { POST } = await import("@/app/api/checkout/route")
+      const res = await POST(makeRequest(validBody()))
+      expect(res.status).toBe(404)
+    })
+  })
+
+  describe("fulfillmentCents clamping", () => {
+    it("clamps fulfillmentCents below min (800) up to 800", async () => {
+      const { POST } = await import("@/app/api/checkout/route")
+      await POST(makeRequest(validBody({ fulfillmentCents: 100 })))
+      expect(mockCalculatePrice).toHaveBeenCalledWith(800, DROP.markupCents, expect.any(Number))
+    })
+
+    it("clamps fulfillmentCents above max (5000) down to 5000", async () => {
+      const { POST } = await import("@/app/api/checkout/route")
+      await POST(makeRequest(validBody({ fulfillmentCents: 9999 })))
+      expect(mockCalculatePrice).toHaveBeenCalledWith(5000, DROP.markupCents, expect.any(Number))
+    })
+
+    it("passes fulfillmentCents unchanged when within valid range", async () => {
+      const { POST } = await import("@/app/api/checkout/route")
+      await POST(makeRequest(validBody({ fulfillmentCents: 1350 })))
+      expect(mockCalculatePrice).toHaveBeenCalledWith(1350, DROP.markupCents, expect.any(Number))
+    })
+
+    it("accepts boundary value of 800", async () => {
+      const { POST } = await import("@/app/api/checkout/route")
+      await POST(makeRequest(validBody({ fulfillmentCents: 800 })))
+      expect(mockCalculatePrice).toHaveBeenCalledWith(800, DROP.markupCents, expect.any(Number))
+    })
+
+    it("accepts boundary value of 5000", async () => {
+      const { POST } = await import("@/app/api/checkout/route")
+      await POST(makeRequest(validBody({ fulfillmentCents: 5000 })))
+      expect(mockCalculatePrice).toHaveBeenCalledWith(5000, DROP.markupCents, expect.any(Number))
+    })
+  })
+
+  describe("happy path", () => {
+    it("returns 200 with checkout URL", async () => {
+      const { POST } = await import("@/app/api/checkout/route")
+      const res = await POST(makeRequest(validBody()))
+      expect(res.status).toBe(200)
+      const json = await res.json()
+      expect(json.url).toBe("https://checkout.stripe.com/session")
+    })
+
+    it("stores fulfillmentCents in Stripe session metadata", async () => {
+      const { POST } = await import("@/app/api/checkout/route")
+      await POST(makeRequest(validBody({ fulfillmentCents: 1350 })))
+      expect(mockSessionsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({ fulfillmentCents: "1350" }),
+        }),
+      )
+    })
+
+    it("passes shippingCents derived from selectedRate.rate to metadata", async () => {
+      const { POST } = await import("@/app/api/checkout/route")
+      await POST(makeRequest(validBody()))
+      expect(mockSessionsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({ shippingCents: "599" }),
+        }),
+      )
+    })
+  })
+})

--- a/src/test/pricing.test.ts
+++ b/src/test/pricing.test.ts
@@ -21,9 +21,8 @@ describe("calculatePrice", () => {
 
   it("applicationFee = serviceFee + fulfillmentCents + shippingCents + stripeFee", () => {
     const shippingCents = 499;
-    const { buyerTotal, serviceFee, applicationFee, fulfillmentCents } = calculatePrice(1200, 500, shippingCents);
-    const totalCharge = buyerTotal + shippingCents;
-    const stripeFee = Math.round(totalCharge * STRIPE_PERCENT + STRIPE_FIXED);
+    const { grandTotal, serviceFee, applicationFee, fulfillmentCents } = calculatePrice(1200, 500, shippingCents);
+    const stripeFee = Math.round(grandTotal * STRIPE_PERCENT + STRIPE_FIXED);
     expect(applicationFee).toBe(serviceFee + fulfillmentCents + shippingCents + stripeFee);
   });
 
@@ -34,9 +33,8 @@ describe("calculatePrice", () => {
 
   it("platform nets serviceFee + baseCents + shippingCents after Stripe deducts its fee", () => {
     const shippingCents = 600;
-    const { buyerTotal, applicationFee, serviceFee, fulfillmentCents } = calculatePrice(1200, 800, shippingCents);
-    const totalCharge = buyerTotal + shippingCents;
-    const stripeFee = Math.round(totalCharge * STRIPE_PERCENT + STRIPE_FIXED);
+    const { grandTotal, applicationFee, serviceFee, fulfillmentCents } = calculatePrice(1200, 800, shippingCents);
+    const stripeFee = Math.round(grandTotal * STRIPE_PERCENT + STRIPE_FIXED);
     const platformNet = applicationFee - stripeFee;
     expect(platformNet).toBe(serviceFee + fulfillmentCents + shippingCents);
   });

--- a/src/test/pricing.test.ts
+++ b/src/test/pricing.test.ts
@@ -6,42 +6,68 @@ const STRIPE_FIXED = 30;
 const PLATFORM_RATE = 0.12;
 
 describe("calculatePrice", () => {
-  it("creator nets markup exactly", () => {
-    const { buyerTotal, serviceFee, creatorNet } = calculatePrice(1000, 500);
-    const stripeFee = Math.round(buyerTotal * STRIPE_PERCENT + STRIPE_FIXED);
-    expect(creatorNet).toBe(buyerTotal - stripeFee - serviceFee - 1000);
+  it("creator nets markupCents (±1 cent rounding from ceil)", () => {
+    const { creatorNet } = calculatePrice(1200, 800);
+    // ceil in gross-up can add 1 cent to creatorNet
+    expect(creatorNet).toBeGreaterThanOrEqual(800);
+    expect(creatorNet).toBeLessThanOrEqual(801);
   });
 
-  it("creatorNet >= markupCents (gross-up covers fees)", () => {
-    const { creatorNet } = calculatePrice(1000, 500);
-    expect(creatorNet).toBeGreaterThanOrEqual(500);
+  it("creator nets markupCents with shipping (±1 cent rounding)", () => {
+    const { creatorNet } = calculatePrice(1200, 800, 599);
+    expect(creatorNet).toBeGreaterThanOrEqual(800);
+    expect(creatorNet).toBeLessThanOrEqual(801);
   });
 
-  it("buyerTotal > baseCents + markupCents", () => {
-    const { buyerTotal } = calculatePrice(2000, 800);
-    expect(buyerTotal).toBeGreaterThan(2800);
+  it("applicationFee = serviceFee + fulfillmentCents + shippingCents + stripeFee", () => {
+    const shippingCents = 499;
+    const { buyerTotal, serviceFee, applicationFee, fulfillmentCents } = calculatePrice(1200, 500, shippingCents);
+    const totalCharge = buyerTotal + shippingCents;
+    const stripeFee = Math.round(totalCharge * STRIPE_PERCENT + STRIPE_FIXED);
+    expect(applicationFee).toBe(serviceFee + fulfillmentCents + shippingCents + stripeFee);
+  });
+
+  it("fulfillmentCents equals baseCents", () => {
+    const { fulfillmentCents } = calculatePrice(1200, 500, 300);
+    expect(fulfillmentCents).toBe(1200);
+  });
+
+  it("platform nets serviceFee + baseCents + shippingCents after Stripe deducts its fee", () => {
+    const shippingCents = 600;
+    const { buyerTotal, applicationFee, serviceFee, fulfillmentCents } = calculatePrice(1200, 800, shippingCents);
+    const totalCharge = buyerTotal + shippingCents;
+    const stripeFee = Math.round(totalCharge * STRIPE_PERCENT + STRIPE_FIXED);
+    const platformNet = applicationFee - stripeFee;
+    expect(platformNet).toBe(serviceFee + fulfillmentCents + shippingCents);
+  });
+
+  it("buyerTotal > baseCents + markupCents (gross-up adds fees)", () => {
+    const { buyerTotal } = calculatePrice(1200, 800);
+    expect(buyerTotal).toBeGreaterThan(2000);
   });
 
   it("serviceFee ~= 12% of buyerTotal", () => {
-    const { buyerTotal, serviceFee } = calculatePrice(1500, 600);
+    const { buyerTotal, serviceFee } = calculatePrice(1500, 600, 400);
     expect(Math.abs(serviceFee - Math.round(buyerTotal * PLATFORM_RATE))).toBeLessThanOrEqual(1);
   });
 
-  it("zero markup — creatorNet ~= 0", () => {
-    const { creatorNet } = calculatePrice(1000, 0);
-    expect(creatorNet).toBeGreaterThanOrEqual(0);
-  });
-
-  it("large markup gross-up math holds", () => {
-    const { buyerTotal, serviceFee, creatorNet } = calculatePrice(500, 5000);
-    const stripeFee = Math.round(buyerTotal * STRIPE_PERCENT + STRIPE_FIXED);
-    expect(buyerTotal - stripeFee - serviceFee - 500).toBe(creatorNet);
+  it("zero markup — creatorNet = 0", () => {
+    const { creatorNet } = calculatePrice(1200, 0);
+    expect(creatorNet).toBe(0);
   });
 
   it("returns integers (cents)", () => {
-    const { buyerTotal, serviceFee, creatorNet } = calculatePrice(999, 301);
+    const { buyerTotal, serviceFee, applicationFee, fulfillmentCents, creatorNet } = calculatePrice(999, 301, 350);
     expect(Number.isInteger(buyerTotal)).toBe(true);
     expect(Number.isInteger(serviceFee)).toBe(true);
+    expect(Number.isInteger(applicationFee)).toBe(true);
+    expect(Number.isInteger(fulfillmentCents)).toBe(true);
     expect(Number.isInteger(creatorNet)).toBe(true);
+  });
+
+  it("shipping=0 behaves like no-shipping call", () => {
+    const a = calculatePrice(1200, 600, 0);
+    const b = calculatePrice(1200, 600);
+    expect(a).toEqual(b);
   });
 });

--- a/src/test/printful.integration.test.ts
+++ b/src/test/printful.integration.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest"
 import {
   PrintfulError,
+  estimateOrderCost,
   generateMockup,
   getShippingRates,
   submitOrder,
@@ -60,6 +61,38 @@ describe.skipIf(!hasKey)("getShippingRates", () => {
         [{ variantId: BC3001_WHITE_M, quantity: 1 }],
       ),
     ).rejects.toBeInstanceOf(PrintfulError)
+  })
+})
+
+// ─── Order estimate ───────────────────────────────────────────────────────────
+
+describe.skipIf(!hasKey)("estimateOrderCost", () => {
+  it("returns a positive integer for a US address", async () => {
+    const cost = await estimateOrderCost(
+      {
+        address1: "1 Hacker Way",
+        city: "Menlo Park",
+        stateCode: "CA",
+        countryCode: "US",
+        zip: "94025",
+      },
+      [{ variantId: BC3001_WHITE_M, quantity: 1 }],
+    )
+    expect(typeof cost).toBe("number")
+    expect(Number.isInteger(cost)).toBe(true)
+    expect(cost).toBeGreaterThan(0)
+  })
+
+  it("returns a higher cost for an EU address (VAT applied)", async () => {
+    const usCost = await estimateOrderCost(
+      { address1: "1 Hacker Way", city: "Menlo Park", stateCode: "CA", countryCode: "US", zip: "94025" },
+      [{ variantId: BC3001_WHITE_M, quantity: 1 }],
+    )
+    const euCost = await estimateOrderCost(
+      { address1: "Nieuwezijds Voorburgwal 147", city: "Amsterdam", countryCode: "NL", zip: "1012 RJ" },
+      [{ variantId: BC3001_WHITE_M, quantity: 1 }],
+    )
+    expect(euCost).toBeGreaterThan(usCost)
   })
 })
 

--- a/src/test/printful.integration.test.ts
+++ b/src/test/printful.integration.test.ts
@@ -66,7 +66,7 @@ describe.skipIf(!hasKey)("getShippingRates", () => {
 
 // ─── Order estimate ───────────────────────────────────────────────────────────
 
-describe.skipIf(!hasKey)("estimateOrderCost", () => {
+describe.skipIf(!hasPrintFile)("estimateOrderCost", () => {
   it("returns a positive integer for a US address", async () => {
     const cost = await estimateOrderCost(
       {
@@ -77,6 +77,7 @@ describe.skipIf(!hasKey)("estimateOrderCost", () => {
         zip: "94025",
       },
       [{ variantId: BC3001_WHITE_M, quantity: 1 }],
+      printFileUrl,
     )
     expect(typeof cost).toBe("number")
     expect(Number.isInteger(cost)).toBe(true)
@@ -87,10 +88,12 @@ describe.skipIf(!hasKey)("estimateOrderCost", () => {
     const usCost = await estimateOrderCost(
       { address1: "1 Hacker Way", city: "Menlo Park", stateCode: "CA", countryCode: "US", zip: "94025" },
       [{ variantId: BC3001_WHITE_M, quantity: 1 }],
+      printFileUrl,
     )
     const euCost = await estimateOrderCost(
       { address1: "Nieuwezijds Voorburgwal 147", city: "Amsterdam", countryCode: "NL", zip: "1012 RJ" },
       [{ variantId: BC3001_WHITE_M, quantity: 1 }],
+      printFileUrl,
     )
     expect(euCost).toBeGreaterThan(usCost)
   })

--- a/src/test/shipping-rates.test.ts
+++ b/src/test/shipping-rates.test.ts
@@ -10,6 +10,9 @@ vi.mock("@/lib/db", () => ({
 
 vi.mock("@/lib/db/schema", () => ({ drop: "drop-table" }))
 
+const mockGetSignedUrl = vi.fn()
+vi.mock("@/lib/storage", () => ({ getSignedUrl: mockGetSignedUrl }))
+
 const mockGetShippingRates = vi.fn()
 const mockEstimateOrderCost = vi.fn()
 vi.mock("@/lib/printful", () => ({
@@ -29,7 +32,8 @@ vi.mock("@/lib/printful", () => ({
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
 const DROP_ID = "123e4567-e89b-12d3-a456-426614174000"
-const DROP = { id: DROP_ID, status: "live" }
+const PRINT_FILE_URL = "https://example.com/print.png"
+const DROP = { id: DROP_ID, status: "live", printFileKey: "designs/test.png" }
 
 const RATES = [
   { id: "STANDARD", name: "Standard", rate: "5.99", currency: "USD", minDeliveryDays: 3, maxDeliveryDays: 5 },
@@ -64,6 +68,7 @@ function validBody(overrides?: Record<string, unknown>) {
 beforeEach(() => {
   vi.clearAllMocks()
   mockFindFirst.mockResolvedValue(DROP)
+  mockGetSignedUrl.mockResolvedValue(PRINT_FILE_URL)
   mockGetShippingRates.mockResolvedValue(RATES)
   mockEstimateOrderCost.mockResolvedValue(1350)
 })
@@ -145,6 +150,17 @@ describe("POST /api/shipping-rates", () => {
       expect(res.status).toBe(422)
       const json = await res.json()
       expect(json.error).toContain("shipping rates")
+    })
+
+    it("falls back to BASE_SHIRT_COST_CENTS when estimateOrderCost fails", async () => {
+      const { PrintfulError } = await import("@/lib/printful")
+      mockEstimateOrderCost.mockRejectedValue(new PrintfulError(404, "NotFound", "Not found"))
+      const { POST } = await import("@/app/api/shipping-rates/route")
+      const res = await POST(makeRequest(validBody()))
+      expect(res.status).toBe(200)
+      const json = await res.json()
+      expect(json.rates).toEqual(RATES)
+      expect(json.fulfillmentCents).toBe(1200)
     })
   })
 })

--- a/src/test/shipping-rates.test.ts
+++ b/src/test/shipping-rates.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockFindFirst = vi.fn()
+
+vi.mock("@/lib/db", () => ({
+  db: { query: { drop: { findFirst: mockFindFirst } } },
+}))
+
+vi.mock("@/lib/db/schema", () => ({ drop: "drop-table" }))
+
+const mockGetShippingRates = vi.fn()
+const mockEstimateOrderCost = vi.fn()
+vi.mock("@/lib/printful", () => ({
+  getShippingRates: mockGetShippingRates,
+  estimateOrderCost: mockEstimateOrderCost,
+  PrintfulError: class PrintfulError extends Error {
+    constructor(
+      public code: number,
+      public reason: string,
+      message: string,
+    ) {
+      super(message)
+    }
+  },
+}))
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const DROP_ID = "123e4567-e89b-12d3-a456-426614174000"
+const DROP = { id: DROP_ID, status: "live" }
+
+const RATES = [
+  { id: "STANDARD", name: "Standard", rate: "5.99", currency: "USD", minDeliveryDays: 3, maxDeliveryDays: 5 },
+]
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request("http://localhost/api/shipping-rates", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  })
+}
+
+function validBody(overrides?: Record<string, unknown>) {
+  return {
+    dropId: DROP_ID,
+    size: "M",
+    address: {
+      name: "Jane Doe",
+      address1: "1 Main St",
+      city: "Portland",
+      stateCode: "OR",
+      zip: "97201",
+      countryCode: "US",
+    },
+    ...overrides,
+  }
+}
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockFindFirst.mockResolvedValue(DROP)
+  mockGetShippingRates.mockResolvedValue(RATES)
+  mockEstimateOrderCost.mockResolvedValue(1350)
+})
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("POST /api/shipping-rates", () => {
+  describe("validation", () => {
+    it("returns 400 on missing dropId", async () => {
+      const { POST } = await import("@/app/api/shipping-rates/route")
+      const body = validBody()
+      delete (body as Record<string, unknown>).dropId
+      const res = await POST(makeRequest(body))
+      expect(res.status).toBe(400)
+    })
+
+    it("returns 400 on invalid size", async () => {
+      const { POST } = await import("@/app/api/shipping-rates/route")
+      const res = await POST(makeRequest(validBody({ size: "XXXL" })))
+      expect(res.status).toBe(400)
+    })
+
+    it("returns 404 when drop not found", async () => {
+      mockFindFirst.mockResolvedValue(null)
+      const { POST } = await import("@/app/api/shipping-rates/route")
+      const res = await POST(makeRequest(validBody()))
+      expect(res.status).toBe(404)
+    })
+
+    it("returns 404 when drop is not live", async () => {
+      mockFindFirst.mockResolvedValue({ ...DROP, status: "paused" })
+      const { POST } = await import("@/app/api/shipping-rates/route")
+      const res = await POST(makeRequest(validBody()))
+      expect(res.status).toBe(404)
+    })
+  })
+
+  describe("happy path", () => {
+    it("returns rates alongside fulfillmentCents", async () => {
+      const { POST } = await import("@/app/api/shipping-rates/route")
+      const res = await POST(makeRequest(validBody()))
+      expect(res.status).toBe(200)
+      const json = await res.json()
+      expect(json.rates).toEqual(RATES)
+      expect(json.fulfillmentCents).toBe(1350)
+    })
+
+    it("calls both getShippingRates and estimateOrderCost", async () => {
+      const { POST } = await import("@/app/api/shipping-rates/route")
+      await POST(makeRequest(validBody()))
+      expect(mockGetShippingRates).toHaveBeenCalledOnce()
+      expect(mockEstimateOrderCost).toHaveBeenCalledOnce()
+    })
+
+    it("passes the same address to both Printful calls", async () => {
+      const { POST } = await import("@/app/api/shipping-rates/route")
+      await POST(makeRequest(validBody()))
+      const ratesAddr = mockGetShippingRates.mock.calls[0][0]
+      const estimateAddr = mockEstimateOrderCost.mock.calls[0][0]
+      expect(ratesAddr).toEqual(estimateAddr)
+    })
+  })
+
+  describe("error handling", () => {
+    it("returns 422 when Printful throws PrintfulError", async () => {
+      const { PrintfulError } = await import("@/lib/printful")
+      mockGetShippingRates.mockRejectedValue(new PrintfulError(400, "bad_address", "Invalid address"))
+      const { POST } = await import("@/app/api/shipping-rates/route")
+      const res = await POST(makeRequest(validBody()))
+      expect(res.status).toBe(422)
+      const json = await res.json()
+      expect(json.error).toContain("address")
+    })
+
+    it("returns 422 with generic message on unknown error", async () => {
+      mockGetShippingRates.mockRejectedValue(new Error("network failure"))
+      const { POST } = await import("@/app/api/shipping-rates/route")
+      const res = await POST(makeRequest(validBody()))
+      expect(res.status).toBe(422)
+      const json = await res.json()
+      expect(json.error).toContain("shipping rates")
+    })
+  })
+})

--- a/src/test/stripe-webhook.test.ts
+++ b/src/test/stripe-webhook.test.ts
@@ -14,6 +14,7 @@ vi.mock("@/lib/stripe", () => ({
 const mockFindFirstOrder = vi.fn()
 const mockFindFirstDrop = vi.fn()
 const mockInsertOrder = vi.fn()
+const mockInsertValues = vi.fn()
 const mockUpdateDrop = vi.fn()
 const mockUpdateOrder = vi.fn()
 const mockSelectUser = vi.fn()
@@ -24,7 +25,7 @@ vi.mock("@/lib/db", () => ({
       order: { findFirst: mockFindFirstOrder },
       drop: { findFirst: mockFindFirstDrop },
     },
-    insert: () => ({ values: () => ({ returning: mockInsertOrder }) }),
+    insert: () => ({ values: mockInsertValues }),
     update: (table: unknown) => ({
       set: () => ({
         where: table === "order-table" ? mockUpdateOrder : mockUpdateDrop,
@@ -68,6 +69,8 @@ const SESSION = {
     size: "M",
     buyerName: "Jane Doe",
     address: JSON.stringify(ADDRESS),
+    fulfillmentCents: "1200",
+    shippingCents: "800",
   },
 }
 
@@ -105,6 +108,7 @@ beforeEach(() => {
 
   mockFindFirstOrder.mockResolvedValue(null)
   mockFindFirstDrop.mockResolvedValue(DROP_RECORD)
+  mockInsertValues.mockReturnValue({ returning: mockInsertOrder })
   mockInsertOrder.mockResolvedValue([NEW_ORDER])
   mockUpdateDrop.mockResolvedValue(undefined)
   mockUpdateOrder.mockResolvedValue(undefined)
@@ -126,7 +130,9 @@ describe("POST /api/stripe/webhook", () => {
       const res = await POST(makeWebhookRequest("checkout.session.completed"))
 
       expect(res.status).toBe(200)
-      expect(mockInsertOrder).toHaveBeenCalled()
+      expect(mockInsertValues).toHaveBeenCalledWith(
+        expect.objectContaining({ fulfillmentCents: 1200, shippingCents: 800 }),
+      )
       expect(mockSubmitOrder).toHaveBeenCalledWith(
         expect.objectContaining({
           recipient: expect.objectContaining({ email: "buyer@example.com" }),


### PR DESCRIPTION
Closes #32

## Summary
- Drop page shows `from $X + shipping` to set honest expectations upfront
- Shipping step displays effective rate per option (includes Stripe fee portion) so the math adds up: from price + shipping = buy button total
- Buy button shows the real grand total computed from actual Printful fulfillment cost + selected shipping rate
- Fixed Printful estimate endpoint (`/orders/estimate-costs`, was `/orders/estimate`); passes print file URL; falls back to `BASE_SHIRT_COST_CENTS` if estimate fails
- Added `grandTotal` to `PriceBreakdown` so call sites no longer manually add `shippingCents`

## Test plan
- [ ] US address: "from $X + shipping" on drop page, shipping rates shown, buy button total = from price + effective shipping
- [ ] EU address (e.g. BE 1090): shipping rates load, buy button shows VAT-inclusive total
- [ ] If Printful estimate fails: falls back gracefully, shipping step still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)