### PR TITLE
Add EMAIL_DEV_MODE to bypass Resend domain requirement

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,10 @@ R2_BUCKET_NAME=
 BETTER_AUTH_SECRET=
 BETTER_AUTH_URL=http://localhost:3000
 RESEND_API_KEY=
+# Set EMAIL_DEV_MODE=true to log emails to console instead of sending (no domain required)
+EMAIL_DEV_MODE=true
+# Override sender address once you have a verified Resend domain
+# EMAIL_FROM="Merch Drop <noreply@yourdomain.com>"
 
 # Stripe
 STRIPE_SECRET_KEY=

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,11 +3,10 @@ import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { emailOTP } from "better-auth/plugins/email-otp";
 import { nextCookies } from "better-auth/next-js";
 import { dash } from "@better-auth/infra";
-import { Resend } from "resend";
 import { db } from "./db";
 import * as schema from "./db/schema";
+import { sendEmail, EMAIL_FROM } from "./email";
 
-const resend = new Resend(process.env.RESEND_API_KEY);
 const trustedOrigins = process.env.NEXT_PUBLIC_URL || "http://localhost:3000";
 
 export const auth = betterAuth({
@@ -41,8 +40,8 @@ export const auth = betterAuth({
           type === "sign-in"
             ? "Your Merch Drop login code"
             : "Verify your email";
-        const result = await resend.emails.send({
-          from: "Merch Drop <noreply@resend.dev>",
+        await sendEmail({
+          from: EMAIL_FROM,
           to: email,
           subject,
           text: `Your verification code is: ${otp}\n\nExpires in 5 minutes.`,

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,11 +1,28 @@
 import { Resend } from "resend"
 
 const resend = new Resend(process.env.RESEND_API_KEY)
-const FROM = "Merch Drop <noreply@resend.dev>"
+
+const DEV_MODE = process.env.EMAIL_DEV_MODE === "true"
+export const EMAIL_FROM = process.env.EMAIL_FROM ?? "Merch Drop <noreply@resend.dev>"
+
+type EmailPayload = {
+  from: string
+  to: string
+  subject: string
+  text: string
+}
+
+export async function sendEmail(payload: EmailPayload) {
+  if (DEV_MODE) {
+    console.log("[EMAIL DEV MODE]\n" + JSON.stringify(payload, null, 2))
+    return
+  }
+  await resend.emails.send(payload)
+}
 
 export async function sendOrderCancelledBuyer(to: string, dropTitle: string) {
-  await resend.emails.send({
-    from: FROM,
+  await sendEmail({
+    from: EMAIL_FROM,
     to,
     subject: `Your order for "${dropTitle}" has been cancelled`,
     text: `We're sorry, but your order for "${dropTitle}" could not be fulfilled by our print partner.\n\nA full refund has been issued and should appear within 5–10 business days depending on your bank.\n\nIf you have questions, reply to this email.`,
@@ -13,8 +30,8 @@ export async function sendOrderCancelledBuyer(to: string, dropTitle: string) {
 }
 
 export async function sendOrderCancelledCreator(to: string, dropTitle: string) {
-  await resend.emails.send({
-    from: FROM,
+  await sendEmail({
+    from: EMAIL_FROM,
     to,
     subject: `Order cancelled for your drop "${dropTitle}"`,
     text: `An order for your drop "${dropTitle}" was rejected by our print partner and has been cancelled.\n\nA full refund has been issued to the buyer. Please review your print file in the Drop Manager. If this keeps happening, contact support.`,


### PR DESCRIPTION
When EMAIL_DEV_MODE=true, all emails (transactional + OTP) are logged
to console instead of sent, so testers can work without a verified domain.

Also centralises the sender address under EMAIL_FROM env var and removes
the duplicate Resend client in auth.ts.

https://claude.ai/code/session_01TaeFf6kCtGAcQvo5nYsomS