### PR TITLE
Collapse checkout to 2-step flow

### DIFF
--- a/src/app/[creatorSlug]/[dropSlug]/page.tsx
+++ b/src/app/[creatorSlug]/[dropSlug]/page.tsx
@@ -96,7 +96,6 @@ export default async function PublicDropPage({ params }: Props) {
               {drop.description && (
                 <p className="text-muted-foreground">{drop.description}</p>
               )}
-              <p className="text-2xl font-medium">{priceDisplay}</p>
             </div>
 
             <BuyForm dropId={drop.id} priceDisplay={priceDisplay} markupCents={drop.markupCents} />

--- a/src/components/drops/buy-form.tsx
+++ b/src/components/drops/buy-form.tsx
@@ -9,7 +9,7 @@ import { calculatePrice } from "@/lib/pricing"
 const SIZES = ["S", "M", "L", "XL", "2XL"] as const
 type Size = (typeof SIZES)[number]
 
-type Step = "size" | "address" | "shipping"
+type Step = "details" | "shipping"
 
 interface Address {
   name: string
@@ -35,9 +35,15 @@ interface BuyFormProps {
   markupCents: number
 }
 
+function formatCents(cents: number) {
+  return `$${(cents / 100).toFixed(2)}`
+}
+
 export function BuyForm({ dropId, priceDisplay, markupCents }: BuyFormProps) {
-  const [step, setStep] = useState<Step>("size")
+  const [step, setStep] = useState<Step>("details")
   const [size, setSize] = useState<Size | null>(null)
+  const [isEditingSize, setIsEditingSize] = useState(true)
+  const [isEditingAddress, setIsEditingAddress] = useState(false)
   const [address, setAddress] = useState<Address>({
     name: "",
     address1: "",
@@ -57,6 +63,7 @@ export function BuyForm({ dropId, priceDisplay, markupCents }: BuyFormProps) {
   }
 
   async function fetchRates() {
+    if (!size) return
     setLoading(true)
     setError(null)
     const res = await fetch("/api/shipping-rates", {
@@ -100,124 +107,157 @@ export function BuyForm({ dropId, priceDisplay, markupCents }: BuyFormProps) {
     }
   }
 
-  if (step === "size") {
-    return (
-      <div className="flex flex-col gap-4">
-        <div>
-          <p className="mb-2 text-sm font-medium">Size</p>
-          <div className="flex flex-wrap gap-2">
-            {SIZES.map((s) => (
-              <button
-                key={s}
-                onClick={() => setSize(s)}
-                className={`min-w-12 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors ${
-                  size === s
-                    ? "border-primary bg-primary text-primary-foreground"
-                    : "border-border bg-background hover:bg-muted"
-                }`}
-              >
-                {s}
-              </button>
-            ))}
-          </div>
-        </div>
-        <Button size="lg" disabled={!size} onClick={() => setStep("address")} className="w-full">
-          {`Continue — ${priceDisplay}`}
-        </Button>
-      </div>
-    )
-  }
-
-  if (step === "address") {
-    const canContinue =
+  if (step === "details") {
+    const hasAddress = Boolean(
       address.name.trim() &&
-      address.address1.trim() &&
-      address.city.trim() &&
-      address.zip.trim() &&
-      address.countryCode.length === 2
+        address.address1.trim() &&
+        address.city.trim() &&
+        address.zip.trim() &&
+        address.countryCode.length === 2
+    )
+    const canContinue = size !== null && hasAddress
 
     return (
-      <div className="flex flex-col gap-4">
-        <p className="text-sm font-medium">Shipping address</p>
-        <div className="grid gap-3">
-          <div className="grid gap-1.5">
-            <Label htmlFor="name">Full name</Label>
-            <Input id="name" value={address.name} onChange={(e) => patch("name", e.target.value)} />
-          </div>
-          <div className="grid gap-1.5">
-            <Label htmlFor="address1">Address</Label>
-            <Input
-              id="address1"
-              value={address.address1}
-              onChange={(e) => patch("address1", e.target.value)}
-            />
-          </div>
-          <div className="grid grid-cols-2 gap-3">
-            <div className="grid gap-1.5">
-              <Label htmlFor="city">City</Label>
-              <Input id="city" value={address.city} onChange={(e) => patch("city", e.target.value)} />
+      <form
+        className="flex flex-col gap-4"
+        onSubmit={(event) => {
+          event.preventDefault()
+          void fetchRates()
+        }}
+      >
+        <div className="rounded-md bg-muted/40 px-4 py-3">
+          <p className="text-sm text-muted-foreground">Product</p>
+          <p className="text-lg font-semibold">{priceDisplay}</p>
+        </div>
+        <div className="rounded-md border border-border">
+          <div className="flex items-center justify-between gap-3 px-4 py-3">
+            <div>
+              <p className="text-sm font-medium">Size</p>
+              {size && !isEditingSize && <p className="text-sm text-muted-foreground">{size}</p>}
             </div>
-            <div className="grid gap-1.5">
-              <Label htmlFor="zip">ZIP / Postal</Label>
-              <Input id="zip" value={address.zip} onChange={(e) => patch("zip", e.target.value)} />
-            </div>
+            {!isEditingSize && (
+              <button
+                type="button"
+                onClick={() => {
+                  setIsEditingSize(true)
+                  setIsEditingAddress(false)
+                }}
+                className="text-sm font-medium text-primary hover:underline"
+              >
+                {size ? "Change" : "Choose"}
+              </button>
+            )}
           </div>
-          <div className="grid grid-cols-2 gap-3">
-            <div className="grid gap-1.5">
-              <Label htmlFor="stateCode">State / Province</Label>
-              <Input
-                id="stateCode"
-                placeholder="Optional"
-                value={address.stateCode}
-                onChange={(e) => patch("stateCode", e.target.value)}
-              />
+          {isEditingSize && (
+            <div className="border-t border-border px-4 py-3">
+              <div className="flex flex-wrap gap-2">
+                {SIZES.map((s) => (
+                  <button
+                    key={s}
+                    type="button"
+                    onClick={() => {
+                      setSize(s)
+                      setIsEditingSize(false)
+                      setIsEditingAddress(!hasAddress)
+                    }}
+                    className={`min-w-12 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors ${
+                      size === s
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-border bg-background hover:bg-muted"
+                    }`}
+                  >
+                    {s}
+                  </button>
+                ))}
+              </div>
             </div>
-            <div className="grid gap-1.5">
-              <Label htmlFor="countryCode">Country code</Label>
-              <Input
-                id="countryCode"
-                placeholder="US, GB, DE…"
-                maxLength={2}
-                value={address.countryCode}
-                onChange={(e) => patch("countryCode", e.target.value.toUpperCase())}
-              />
+          )}
+        </div>
+        <div className="rounded-md border border-border">
+          <div className="flex items-center justify-between gap-3 px-4 py-3">
+            <div>
+              <p className="text-sm font-medium">Shipping address</p>
+              {hasAddress && !isEditingAddress && (
+                <p className="text-sm text-muted-foreground">
+                  {address.city}, {address.countryCode}
+                </p>
+              )}
             </div>
+            {!isEditingAddress && (
+              <button
+                type="button"
+                onClick={() => {
+                  setIsEditingAddress(true)
+                  setIsEditingSize(false)
+                }}
+                className="text-sm font-medium text-primary hover:underline"
+              >
+                {hasAddress ? "Change" : "Add"}
+              </button>
+            )}
           </div>
+          {isEditingAddress && (
+            <div className="grid gap-3 border-t border-border px-4 py-3">
+              <div className="grid gap-1.5">
+                <Label htmlFor="name">Full name</Label>
+                <Input id="name" value={address.name} onChange={(e) => patch("name", e.target.value)} />
+              </div>
+              <div className="grid gap-1.5">
+                <Label htmlFor="address1">Address</Label>
+                <Input
+                  id="address1"
+                  value={address.address1}
+                  onChange={(e) => patch("address1", e.target.value)}
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="grid gap-1.5">
+                  <Label htmlFor="city">City</Label>
+                  <Input id="city" value={address.city} onChange={(e) => patch("city", e.target.value)} />
+                </div>
+                <div className="grid gap-1.5">
+                  <Label htmlFor="zip">ZIP / Postal</Label>
+                  <Input id="zip" value={address.zip} onChange={(e) => patch("zip", e.target.value)} />
+                </div>
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="grid gap-1.5">
+                  <Label htmlFor="stateCode">State / Province</Label>
+                  <Input
+                    id="stateCode"
+                    placeholder="Optional"
+                    value={address.stateCode}
+                    onChange={(e) => patch("stateCode", e.target.value)}
+                  />
+                </div>
+                <div className="grid gap-1.5">
+                  <Label htmlFor="countryCode">Country code</Label>
+                  <Input
+                    id="countryCode"
+                    placeholder="US, GB, DE…"
+                    maxLength={2}
+                    value={address.countryCode}
+                    onChange={(e) => patch("countryCode", e.target.value.toUpperCase())}
+                  />
+                </div>
+              </div>
+            </div>
+          )}
         </div>
         {error && <p className="text-sm text-destructive">{error}</p>}
-        <div className="flex gap-2">
-          <Button
-            variant="outline"
-            onClick={() => {
-              setStep("size")
-              setError(null)
-            }}
-            className="flex-1"
-          >
-            Back
-          </Button>
-          <Button disabled={!canContinue || loading} onClick={fetchRates} className="flex-1">
-            {loading ? "Fetching rates…" : "Get shipping rates"}
-          </Button>
-        </div>
-      </div>
+        <Button type="submit" disabled={!canContinue || loading} className="w-full">
+          {loading ? "Fetching rates…" : "Calculate shipping"}
+        </Button>
+      </form>
     )
   }
 
   // step === "shipping"
   const selectedRate = rates.find((r) => r.id === selectedRateId)
 
-  const baseGrandTotal =
-    fulfillmentCents !== null ? calculatePrice(fulfillmentCents, markupCents, 0).grandTotal : null
-
   function formatRate(rate: ShippingRate) {
     const rawCents = Math.round(parseFloat(rate.rate) * 100)
-    let effectiveCents = rawCents
-    if (fulfillmentCents !== null && baseGrandTotal !== null) {
-      const { grandTotal } = calculatePrice(fulfillmentCents, markupCents, rawCents)
-      effectiveCents = grandTotal - baseGrandTotal
-    }
-    const price = effectiveCents === 0 ? "Free" : `$${(effectiveCents / 100).toFixed(2)}`
+    const price = rawCents === 0 ? "Free" : formatCents(rawCents)
     const days =
       rate.minDeliveryDays != null
         ? ` · ${rate.minDeliveryDays}–${rate.maxDeliveryDays ?? rate.minDeliveryDays} days`
@@ -225,12 +265,16 @@ export function BuyForm({ dropId, priceDisplay, markupCents }: BuyFormProps) {
     return { price, days }
   }
 
-  const buyerTotalDisplay = (() => {
-    if (!selectedRate || fulfillmentCents === null) return priceDisplay
+  const priceBreakdown = (() => {
+    if (!selectedRate || fulfillmentCents === null) return null
     const shippingCents = Math.round(parseFloat(selectedRate.rate) * 100)
-    const { grandTotal } = calculatePrice(fulfillmentCents, markupCents, shippingCents)
-    return `$${(grandTotal / 100).toFixed(2)}`
+    return {
+      shippingCents,
+      ...calculatePrice(fulfillmentCents, markupCents, shippingCents),
+    }
   })()
+
+  const buyTotalDisplay = priceBreakdown ? formatCents(priceBreakdown.grandTotal) : priceDisplay
 
   return (
     <div className="flex flex-col gap-4">
@@ -257,12 +301,28 @@ export function BuyForm({ dropId, priceDisplay, markupCents }: BuyFormProps) {
           )
         })}
       </div>
+      {priceBreakdown && (
+        <div className="rounded-md border border-border bg-muted/30 p-4 text-sm">
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-muted-foreground">Product</span>
+            <span className="font-medium">{formatCents(priceBreakdown.buyerTotal)}</span>
+          </div>
+          <div className="mt-2 flex items-center justify-between gap-3">
+            <span className="text-muted-foreground">Shipping</span>
+            <span className="font-medium">{formatCents(priceBreakdown.shippingCents)}</span>
+          </div>
+          <div className="mt-3 flex items-center justify-between gap-3 border-t border-border pt-3">
+            <span className="font-medium">Total</span>
+            <span className="text-base font-semibold">{formatCents(priceBreakdown.grandTotal)}</span>
+          </div>
+        </div>
+      )}
       {error && <p className="text-sm text-destructive">{error}</p>}
       <div className="flex gap-2">
         <Button
           variant="outline"
           onClick={() => {
-            setStep("address")
+            setStep("details")
             setError(null)
           }}
           className="flex-1"
@@ -270,7 +330,7 @@ export function BuyForm({ dropId, priceDisplay, markupCents }: BuyFormProps) {
           Back
         </Button>
         <Button disabled={!selectedRateId || loading} onClick={handleBuy} className="flex-1">
-          {loading ? "Redirecting…" : `Buy — ${buyerTotalDisplay}`}
+          {loading ? "Redirecting…" : `Buy — ${buyTotalDisplay}`}
         </Button>
       </div>
     </div>

--- a/src/test/buy-form.test.tsx
+++ b/src/test/buy-form.test.tsx
@@ -15,7 +15,16 @@ async function renderForm(priceDisplay = "from $28.50", markupCents = 1500) {
 }
 
 const SHIPPING_RATES_RESPONSE = {
-  rates: [{ id: "STANDARD", name: "Standard", rate: "5.99", currency: "USD", minDeliveryDays: 3, maxDeliveryDays: 5 }],
+  rates: [
+    {
+      id: "STANDARD",
+      name: "Standard",
+      rate: "5.99",
+      currency: "USD",
+      minDeliveryDays: 3,
+      maxDeliveryDays: 5,
+    },
+  ],
   fulfillmentCents: 1350,
 }
 
@@ -25,15 +34,13 @@ async function goToShippingStep() {
   )
 
   await userEvent.click(screen.getByRole("button", { name: "L" }))
-  await userEvent.click(screen.getByRole("button", { name: /continue/i }))
-
   await userEvent.type(screen.getByLabelText("Full name"), "Jane Doe")
   await userEvent.type(screen.getByLabelText("Address"), "1 Main St")
   await userEvent.type(screen.getByLabelText("City"), "Portland")
   await userEvent.type(screen.getByLabelText("ZIP / Postal"), "97201")
   await userEvent.type(screen.getByLabelText("Country code"), "US")
 
-  await userEvent.click(screen.getByRole("button", { name: /get shipping rates/i }))
+  await userEvent.click(screen.getByRole("button", { name: /calculate shipping/i }))
   await screen.findByText(/standard/i)
 }
 
@@ -47,49 +54,52 @@ describe("BuyForm rendering", () => {
     }
   })
 
-  it("renders continue button with price on size step", async () => {
+  it("shows the Stripe-included starting price on the details step", async () => {
     await renderForm("from $28.50 + shipping")
-    expect(screen.getByRole("button", { name: /continue.*from \$28\.50 \+ shipping/i })).toBeInTheDocument()
+    expect(screen.getByText("from $28.50 + shipping")).toBeInTheDocument()
   })
 
-  it("continue button is disabled before size is selected", async () => {
+  it("calculate shipping button is disabled before size and address are entered", async () => {
     await renderForm()
-    expect(screen.getByRole("button", { name: /continue/i })).toBeDisabled()
+    expect(screen.getByRole("button", { name: /calculate shipping/i })).toBeDisabled()
   })
 })
 
 // ─── Size selection ───────────────────────────────────────────────────────────
 
 describe("size selection", () => {
-  it("enables continue button after selecting a size", async () => {
+  it("keeps calculate shipping disabled after only selecting a size", async () => {
     await renderForm()
     await userEvent.click(screen.getByRole("button", { name: "M" }))
-    expect(screen.getByRole("button", { name: /continue/i })).not.toBeDisabled()
+    expect(screen.getByRole("button", { name: /calculate shipping/i })).toBeDisabled()
   })
 
   it("can switch between sizes", async () => {
     await renderForm()
     await userEvent.click(screen.getByRole("button", { name: "M" }))
+    await userEvent.click(screen.getByRole("button", { name: "Change" }))
     await userEvent.click(screen.getByRole("button", { name: "XL" }))
-    expect(screen.getByRole("button", { name: /continue/i })).not.toBeDisabled()
+    expect(screen.getByText("XL")).toBeInTheDocument()
   })
 })
 
-// ─── Address step ─────────────────────────────────────────────────────────────
+// ─── Details step ─────────────────────────────────────────────────────────────
 
-describe("address step", () => {
-  it("advances to address step after selecting a size and clicking continue", async () => {
+describe("details step", () => {
+  it("lets the buyer enter an address before selecting a size", async () => {
     await renderForm()
-    await userEvent.click(screen.getByRole("button", { name: "M" }))
-    await userEvent.click(screen.getByRole("button", { name: /continue/i }))
+    expect(screen.getByRole("button", { name: "M" })).toBeInTheDocument()
+    expect(screen.queryByLabelText("Full name")).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole("button", { name: "Add" }))
+
     expect(screen.getByLabelText("Full name")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Choose" })).toBeInTheDocument()
   })
 
-  it("get shipping rates button is disabled until required fields are filled", async () => {
+  it("calculate shipping button is disabled until required fields are filled", async () => {
     await renderForm()
-    await userEvent.click(screen.getByRole("button", { name: "M" }))
-    await userEvent.click(screen.getByRole("button", { name: /continue/i }))
-    expect(screen.getByRole("button", { name: /get shipping rates/i })).toBeDisabled()
+    expect(screen.getByRole("button", { name: /calculate shipping/i })).toBeDisabled()
   })
 })
 
@@ -100,6 +110,19 @@ describe("shipping step", () => {
     await renderForm()
     await goToShippingStep()
     expect(screen.getByText(/standard/i)).toBeInTheDocument()
+    expect(screen.getAllByText("$5.99")).toHaveLength(2)
+  })
+
+  it("shows a Stripe-matching price breakdown", async () => {
+    await renderForm()
+    await goToShippingStep()
+
+    expect(screen.getByText("Product")).toBeInTheDocument()
+    expect(screen.getByText("$34.05")).toBeInTheDocument()
+    expect(screen.getByText("Shipping")).toBeInTheDocument()
+    expect(screen.getAllByText("$5.99")).toHaveLength(2)
+    expect(screen.getByText("Total")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /buy.*\$40\.04/i })).toBeInTheDocument()
   })
 
   it("calls /api/shipping-rates with address and size", async () => {
@@ -120,13 +143,12 @@ describe("shipping step", () => {
 
     await renderForm()
     await userEvent.click(screen.getByRole("button", { name: "L" }))
-    await userEvent.click(screen.getByRole("button", { name: /continue/i }))
     await userEvent.type(screen.getByLabelText("Full name"), "Jane Doe")
     await userEvent.type(screen.getByLabelText("Address"), "1 Main St")
     await userEvent.type(screen.getByLabelText("City"), "Portland")
     await userEvent.type(screen.getByLabelText("ZIP / Postal"), "97201")
     await userEvent.type(screen.getByLabelText("Country code"), "US")
-    await userEvent.click(screen.getByRole("button", { name: /get shipping rates/i }))
+    await userEvent.click(screen.getByRole("button", { name: /calculate shipping/i }))
 
     await screen.findByText("Check your address and try again.")
   })


### PR DESCRIPTION
## Summary
- Collapse the buy form into a 2-step checkout: details, then shipping + buy
- Use an accordion-style first step so size and address feel lighter while staying in one view
- Show raw shipping rates, a product/shipping/total breakdown, and a grand-total buy button before Stripe

## Verification
- /Users/janvandenenden/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node node_modules/vitest/vitest.mjs run src/test/buy-form.test.tsx
- Browser checked on http://localhost:3002/jvde/winter-2026

Closes #36