### PR TITLE
fix: fixed buyer-facing product price

### DIFF
--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,7 +22,6 @@
       "when": 1777538359128,
       "tag": "0002_fat_the_hand",
       "breakpoints": true
-<<<<<<< HEAD
     },
     {
       "idx": 3,

--- a/src/app/[creatorSlug]/[dropSlug]/page.tsx
+++ b/src/app/[creatorSlug]/[dropSlug]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from "next/navigation"
 import Image from "next/image"
 import { getDropBySlug } from "@/lib/drops"
 import { getSignedUrl } from "@/lib/storage"
-import { calculatePrice, BASE_SHIRT_COST_CENTS } from "@/lib/pricing"
+import { fixedProductPrice } from "@/lib/pricing"
 import { BuyForm } from "@/components/drops/buy-form"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 
@@ -66,8 +66,7 @@ export default async function PublicDropPage({ params }: Props) {
     )
   }
 
-  const { buyerTotal } = calculatePrice(BASE_SHIRT_COST_CENTS, drop.markupCents)
-  const priceDisplay = `from $${(buyerTotal / 100).toFixed(2)} + shipping`
+  const productPriceCents = fixedProductPrice(drop.markupCents)
 
   return (
     <main className="flex min-h-screen items-center justify-center p-8">
@@ -98,7 +97,7 @@ export default async function PublicDropPage({ params }: Props) {
               )}
             </div>
 
-            <BuyForm dropId={drop.id} priceDisplay={priceDisplay} markupCents={drop.markupCents} />
+            <BuyForm dropId={drop.id} productPriceCents={productPriceCents} />
 
             <div className="space-y-1 text-sm text-muted-foreground">
               <p>Printed &amp; shipped in 3–5 business days.</p>

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -4,7 +4,7 @@ import { eq } from "drizzle-orm"
 import { db } from "@/lib/db"
 import { drop, user } from "@/lib/db/schema"
 import { stripe } from "@/lib/stripe"
-import { calculatePrice } from "@/lib/pricing"
+import { fixedProductPrice, computeApplicationFee } from "@/lib/pricing"
 
 const addressSchema = z.object({
   name: z.string().min(1),
@@ -64,11 +64,8 @@ export async function POST(request: Request) {
   }
 
   const shippingAmountCents = Math.round(parseFloat(selectedRate.rate) * 100)
-  const { buyerTotal, applicationFee, fulfillmentCents } = calculatePrice(
-    clientFulfillmentCents,
-    record.markupCents,
-    shippingAmountCents,
-  )
+  const productPriceCents = fixedProductPrice(record.markupCents)
+  const { applicationFee } = computeApplicationFee(productPriceCents, clientFulfillmentCents, shippingAmountCents)
 
   const baseUrl = process.env.NEXT_PUBLIC_URL ?? "http://localhost:3000"
   const creatorSlug = creator.slug ?? creator.id
@@ -104,7 +101,7 @@ export async function POST(request: Request) {
       {
         price_data: {
           currency: "usd",
-          unit_amount: buyerTotal,
+          unit_amount: productPriceCents,
           product_data: { name: record.title },
         },
         quantity: 1,
@@ -123,7 +120,7 @@ export async function POST(request: Request) {
       address: JSON.stringify(address),
       shippingRateId: selectedRate.id,
       shippingName: selectedRate.name,
-      fulfillmentCents: String(fulfillmentCents),
+      fulfillmentCents: String(clientFulfillmentCents),
       shippingCents: String(shippingAmountCents),
     },
     success_url: `${dropUrl}/success?session_id={CHECKOUT_SESSION_ID}`,

--- a/src/components/drops/buy-form.tsx
+++ b/src/components/drops/buy-form.tsx
@@ -4,8 +4,6 @@ import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { calculatePrice } from "@/lib/pricing"
-
 const SIZES = ["S", "M", "L", "XL", "2XL"] as const
 type Size = (typeof SIZES)[number]
 
@@ -31,15 +29,14 @@ interface ShippingRate {
 
 interface BuyFormProps {
   dropId: string
-  priceDisplay: string
-  markupCents: number
+  productPriceCents: number
 }
 
 function formatCents(cents: number) {
   return `$${(cents / 100).toFixed(2)}`
 }
 
-export function BuyForm({ dropId, priceDisplay, markupCents }: BuyFormProps) {
+export function BuyForm({ dropId, productPriceCents }: BuyFormProps) {
   const [step, setStep] = useState<Step>("details")
   const [size, setSize] = useState<Size | null>(null)
   const [isEditingSize, setIsEditingSize] = useState(true)
@@ -127,7 +124,7 @@ export function BuyForm({ dropId, priceDisplay, markupCents }: BuyFormProps) {
       >
         <div className="rounded-md bg-muted/40 px-4 py-3">
           <p className="text-sm text-muted-foreground">Product</p>
-          <p className="text-lg font-semibold">{priceDisplay}</p>
+          <p className="text-lg font-semibold">{formatCents(productPriceCents)} + shipping</p>
         </div>
         <div className="rounded-md border border-border">
           <div className="flex items-center justify-between gap-3 px-4 py-3">
@@ -266,15 +263,12 @@ export function BuyForm({ dropId, priceDisplay, markupCents }: BuyFormProps) {
   }
 
   const priceBreakdown = (() => {
-    if (!selectedRate || fulfillmentCents === null) return null
+    if (!selectedRate) return null
     const shippingCents = Math.round(parseFloat(selectedRate.rate) * 100)
-    return {
-      shippingCents,
-      ...calculatePrice(fulfillmentCents, markupCents, shippingCents),
-    }
+    return { shippingCents, grandTotal: productPriceCents + shippingCents }
   })()
 
-  const buyTotalDisplay = priceBreakdown ? formatCents(priceBreakdown.grandTotal) : priceDisplay
+  const buyTotalDisplay = priceBreakdown ? formatCents(priceBreakdown.grandTotal) : formatCents(productPriceCents)
 
   return (
     <div className="flex flex-col gap-4">
@@ -305,7 +299,7 @@ export function BuyForm({ dropId, priceDisplay, markupCents }: BuyFormProps) {
         <div className="rounded-md border border-border bg-muted/30 p-4 text-sm">
           <div className="flex items-center justify-between gap-3">
             <span className="text-muted-foreground">Product</span>
-            <span className="font-medium">{formatCents(priceBreakdown.buyerTotal)}</span>
+            <span className="font-medium">{formatCents(productPriceCents)}</span>
           </div>
           <div className="mt-2 flex items-center justify-between gap-3">
             <span className="text-muted-foreground">Shipping</span>

--- a/src/components/drops/new-drop-form.tsx
+++ b/src/components/drops/new-drop-form.tsx
@@ -15,7 +15,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
-import { calculatePrice, BASE_SHIRT_COST_CENTS } from "@/lib/pricing"
+import { fixedProductPrice, salePriceToMarkupCents, computeApplicationFee, BASE_SHIRT_COST_CENTS } from "@/lib/pricing"
 
 function toSlug(title: string): string {
   return title
@@ -39,7 +39,7 @@ const schema = z.object({
     .regex(/^[a-z0-9-]+$/, "Lowercase letters, numbers, and hyphens only"),
   description: z.string().optional(),
   supportEmail: z.string().email("Enter a valid email address"),
-  markupDollars: z.number().min(0, "Must be 0 or more"),
+  salePriceDollars: z.number().min(0.01, "Must be greater than 0"),
 })
 
 type FormValues = z.infer<typeof schema>
@@ -58,11 +58,11 @@ export function NewDropForm({ creatorSlug }: { creatorSlug: string }) {
     formState: { errors, isSubmitting },
   } = useForm<FormValues>({
     resolver: zodResolver(schema),
-    defaultValues: { markupDollars: 10, slug: "", title: "" },
+    defaultValues: { salePriceDollars: 35, slug: "", title: "" },
   })
 
   const title = watch("title")
-  const markupDollars = watch("markupDollars")
+  const salePriceDollars = watch("salePriceDollars")
 
   useEffect(() => {
     if (!slugEdited && title) {
@@ -71,8 +71,10 @@ export function NewDropForm({ creatorSlug }: { creatorSlug: string }) {
     }
   }, [title, slugEdited, setValue])
 
-  const markupCents = Math.round((markupDollars || 0) * 100)
-  const price = calculatePrice(BASE_SHIRT_COST_CENTS, markupCents)
+  const salePriceCents = Math.round((salePriceDollars || 0) * 100)
+  const markupCents = salePriceToMarkupCents(salePriceCents)
+  const actualSalePriceCents = fixedProductPrice(markupCents)
+  const { creatorNet } = computeApplicationFee(actualSalePriceCents, BASE_SHIRT_COST_CENTS, 0)
 
   async function onSubmit(values: FormValues) {
     setServerError(null)
@@ -84,7 +86,7 @@ export function NewDropForm({ creatorSlug }: { creatorSlug: string }) {
         slug: values.slug,
         description: values.description,
         supportEmail: values.supportEmail,
-        markupCents: Math.round(values.markupDollars * 100),
+        markupCents: salePriceToMarkupCents(Math.round(values.salePriceDollars * 100)),
       }),
     })
 
@@ -174,17 +176,17 @@ export function NewDropForm({ creatorSlug }: { creatorSlug: string }) {
       </div>
 
       <div className="space-y-2">
-        <Label htmlFor="markupDollars">Your markup</Label>
+        <Label htmlFor="salePriceDollars">Sale price</Label>
         <div className="flex items-center gap-2">
           <span className="text-sm text-muted-foreground">$</span>
           <Controller
-            name="markupDollars"
+            name="salePriceDollars"
             control={control}
             render={({ field }) => (
               <Input
-                id="markupDollars"
+                id="salePriceDollars"
                 type="number"
-                min={0}
+                min={0.01}
                 step={0.01}
                 className="w-32"
                 value={field.value}
@@ -195,37 +197,23 @@ export function NewDropForm({ creatorSlug }: { creatorSlug: string }) {
             )}
           />
         </div>
-        {errors.markupDollars && (
+        <p className="text-xs text-muted-foreground">What the buyer pays for the shirt, before shipping.</p>
+        {errors.salePriceDollars && (
           <p className="text-sm text-destructive">
-            {errors.markupDollars.message}
+            {errors.salePriceDollars.message}
           </p>
         )}
       </div>
 
       <Card>
-        <CardHeader>
-          <CardTitle>Price breakdown</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-2 text-sm">
-          <div className="flex justify-between">
-            <span className="text-muted-foreground">Shirt cost</span>
-            <span>${formatCents(BASE_SHIRT_COST_CENTS)}</span>
+        <CardContent className="flex items-center justify-between pt-6 text-sm">
+          <div>
+            <p className="text-muted-foreground">Sale price</p>
+            <p className="text-lg font-semibold">${formatCents(actualSalePriceCents)}</p>
           </div>
-          <div className="flex justify-between">
-            <span className="text-muted-foreground">Your markup</span>
-            <span>${formatCents(markupCents)}</span>
-          </div>
-          <div className="flex justify-between">
-            <span className="text-muted-foreground">Service fee</span>
-            <span>${formatCents(price.serviceFee)}</span>
-          </div>
-          <div className="flex justify-between border-t pt-2 font-medium">
-            <span>Buyer pays</span>
-            <span>${formatCents(price.buyerTotal)}</span>
-          </div>
-          <div className="flex justify-between text-green-600 dark:text-green-400">
-            <span>You earn</span>
-            <span>${formatCents(price.creatorNet)}</span>
+          <div className="text-right">
+            <p className="text-muted-foreground">You earn per shirt</p>
+            <p className="text-lg font-semibold text-green-600 dark:text-green-400">~${formatCents(creatorNet)}</p>
           </div>
         </CardContent>
       </Card>

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -39,3 +39,39 @@ export function calculatePrice(
 
   return { buyerTotal, grandTotal: totalCharge, serviceFee, applicationFee, fulfillmentCents: baseCents, creatorNet };
 }
+
+/** Fixed buyer-facing product price computed from base cost only — no shipping influence. */
+export function fixedProductPrice(markupCents: number): number {
+  return Math.ceil(
+    (BASE_SHIRT_COST_CENTS + markupCents + STRIPE_FIXED_CENTS) /
+      (1 - PLATFORM_FEE_RATE - STRIPE_PERCENT)
+  );
+}
+
+/** Inverse of fixedProductPrice — derive markupCents from a desired sale price. */
+export function salePriceToMarkupCents(salePriceCents: number): number {
+  return Math.max(
+    0,
+    Math.floor(salePriceCents * (1 - PLATFORM_FEE_RATE - STRIPE_PERCENT) - BASE_SHIRT_COST_CENTS - STRIPE_FIXED_CENTS),
+  );
+}
+
+export interface ApplicationFeeBreakdown {
+  applicationFee: number;
+  serviceFee: number;
+  creatorNet: number;
+}
+
+/** Internal fee accounting after product price is fixed. Creator net may differ slightly from markupCents. */
+export function computeApplicationFee(
+  productPriceCents: number,
+  fulfillmentCents: number,
+  shippingCents: number,
+): ApplicationFeeBreakdown {
+  const totalCharge = productPriceCents + shippingCents;
+  const stripeFee = Math.round(totalCharge * STRIPE_PERCENT + STRIPE_FIXED_CENTS);
+  const serviceFee = Math.round(productPriceCents * PLATFORM_FEE_RATE);
+  const applicationFee = serviceFee + fulfillmentCents + shippingCents + stripeFee;
+  const creatorNet = totalCharge - applicationFee;
+  return { applicationFee, serviceFee, creatorNet };
+}

--- a/src/test/buy-form.test.tsx
+++ b/src/test/buy-form.test.tsx
@@ -9,9 +9,9 @@ beforeEach(() => {
 
 afterEach(cleanup)
 
-async function renderForm(priceDisplay = "from $28.50", markupCents = 1500) {
+async function renderForm(productPriceCents = 3405) {
   const { BuyForm } = await import("@/components/drops/buy-form")
-  render(<BuyForm dropId="drop-1" priceDisplay={priceDisplay} markupCents={markupCents} />)
+  render(<BuyForm dropId="drop-1" productPriceCents={productPriceCents} />)
 }
 
 const SHIPPING_RATES_RESPONSE = {
@@ -54,9 +54,9 @@ describe("BuyForm rendering", () => {
     }
   })
 
-  it("shows the Stripe-included starting price on the details step", async () => {
-    await renderForm("from $28.50 + shipping")
-    expect(screen.getByText("from $28.50 + shipping")).toBeInTheDocument()
+  it("shows the fixed product price on the details step", async () => {
+    await renderForm(2850)
+    expect(screen.getByText("$28.50 + shipping")).toBeInTheDocument()
   })
 
   it("calculate shipping button is disabled before size and address are entered", async () => {
@@ -123,6 +123,14 @@ describe("shipping step", () => {
     expect(screen.getAllByText("$5.99")).toHaveLength(2)
     expect(screen.getByText("Total")).toBeInTheDocument()
     expect(screen.getByRole("button", { name: /buy.*\$40\.04/i })).toBeInTheDocument()
+  })
+
+  it("product price on step 2 matches step 1", async () => {
+    await renderForm(3405)
+    expect(screen.getByText("$34.05 + shipping")).toBeInTheDocument()
+    await goToShippingStep()
+    // step 1 unmounts; product row in breakdown must show the same price
+    expect(screen.getByText("$34.05")).toBeInTheDocument()
   })
 
   it("calls /api/shipping-rates with address and size", async () => {

--- a/src/test/checkout.test.ts
+++ b/src/test/checkout.test.ts
@@ -24,9 +24,11 @@ vi.mock("@/lib/stripe", () => ({
   stripe: { checkout: { sessions: { create: mockSessionsCreate } } },
 }))
 
-const mockCalculatePrice = vi.fn()
+const mockFixedProductPrice = vi.fn()
+const mockComputeApplicationFee = vi.fn()
 vi.mock("@/lib/pricing", () => ({
-  calculatePrice: mockCalculatePrice,
+  fixedProductPrice: mockFixedProductPrice,
+  computeApplicationFee: mockComputeApplicationFee,
 }))
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
@@ -94,10 +96,9 @@ beforeEach(() => {
 
   mockFindFirstDrop.mockResolvedValue(DROP)
   mockFindFirstUser.mockResolvedValue(CREATOR)
-  mockCalculatePrice.mockReturnValue({
-    buyerTotal: 2800,
+  mockFixedProductPrice.mockReturnValue(2800)
+  mockComputeApplicationFee.mockReturnValue({
     applicationFee: 500,
-    fulfillmentCents: 1350,
     serviceFee: 200,
     creatorNet: 1000,
   })
@@ -148,32 +149,32 @@ describe("POST /api/checkout", () => {
       const { POST } = await import("@/app/api/checkout/route")
       const res = await POST(makeRequest(validBody({ fulfillmentCents: 100 })))
       expect(res.status).toBe(400)
-      expect(mockCalculatePrice).not.toHaveBeenCalled()
+      expect(mockComputeApplicationFee).not.toHaveBeenCalled()
     })
 
     it("rejects fulfillmentCents above max (5000) with 400", async () => {
       const { POST } = await import("@/app/api/checkout/route")
       const res = await POST(makeRequest(validBody({ fulfillmentCents: 9999 })))
       expect(res.status).toBe(400)
-      expect(mockCalculatePrice).not.toHaveBeenCalled()
+      expect(mockComputeApplicationFee).not.toHaveBeenCalled()
     })
 
     it("passes fulfillmentCents unchanged when within valid range", async () => {
       const { POST } = await import("@/app/api/checkout/route")
       await POST(makeRequest(validBody({ fulfillmentCents: 1350 })))
-      expect(mockCalculatePrice).toHaveBeenCalledWith(1350, DROP.markupCents, expect.any(Number))
+      expect(mockComputeApplicationFee).toHaveBeenCalledWith(expect.any(Number), 1350, expect.any(Number))
     })
 
     it("accepts boundary value of 800", async () => {
       const { POST } = await import("@/app/api/checkout/route")
       await POST(makeRequest(validBody({ fulfillmentCents: 800 })))
-      expect(mockCalculatePrice).toHaveBeenCalledWith(800, DROP.markupCents, expect.any(Number))
+      expect(mockComputeApplicationFee).toHaveBeenCalledWith(expect.any(Number), 800, expect.any(Number))
     })
 
     it("accepts boundary value of 5000", async () => {
       const { POST } = await import("@/app/api/checkout/route")
       await POST(makeRequest(validBody({ fulfillmentCents: 5000 })))
-      expect(mockCalculatePrice).toHaveBeenCalledWith(5000, DROP.markupCents, expect.any(Number))
+      expect(mockComputeApplicationFee).toHaveBeenCalledWith(expect.any(Number), 5000, expect.any(Number))
     })
   })
 
@@ -184,6 +185,21 @@ describe("POST /api/checkout", () => {
       expect(res.status).toBe(200)
       const json = await res.json()
       expect(json.url).toBe("https://checkout.stripe.com/session")
+    })
+
+    it("uses fixedProductPrice as Stripe line item unit_amount", async () => {
+      mockFixedProductPrice.mockReturnValue(3500)
+      const { POST } = await import("@/app/api/checkout/route")
+      await POST(makeRequest(validBody()))
+      expect(mockSessionsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          line_items: expect.arrayContaining([
+            expect.objectContaining({
+              price_data: expect.objectContaining({ unit_amount: 3500 }),
+            }),
+          ]),
+        }),
+      )
     })
 
     it("stores fulfillmentCents in Stripe session metadata", async () => {

--- a/src/test/pricing.test.ts
+++ b/src/test/pricing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { calculatePrice } from "../lib/pricing";
+import { calculatePrice, fixedProductPrice, computeApplicationFee } from "../lib/pricing";
 
 const STRIPE_PERCENT = 0.029;
 const STRIPE_FIXED = 30;
@@ -67,5 +67,49 @@ describe("calculatePrice", () => {
     const a = calculatePrice(1200, 600, 0);
     const b = calculatePrice(1200, 600);
     expect(a).toEqual(b);
+  });
+});
+
+describe("fixedProductPrice", () => {
+  it("returns an integer", () => {
+    expect(Number.isInteger(fixedProductPrice(800))).toBe(true);
+  });
+
+  it("is stable — same result regardless of shipping", () => {
+    const price = fixedProductPrice(1000);
+    expect(price).toBe(fixedProductPrice(1000));
+  });
+
+  it("increases with higher markupCents", () => {
+    expect(fixedProductPrice(1000)).toBeGreaterThan(fixedProductPrice(500));
+  });
+
+  it("is greater than BASE_SHIRT_COST_CENTS + markupCents (gross-up adds fees)", () => {
+    const price = fixedProductPrice(800);
+    expect(price).toBeGreaterThan(1200 + 800);
+  });
+});
+
+describe("computeApplicationFee", () => {
+  it("applicationFee = serviceFee + fulfillmentCents + shippingCents + stripeFee", () => {
+    const productPriceCents = 3200;
+    const fulfillmentCents = 1350;
+    const shippingCents = 599;
+    const { applicationFee, serviceFee } = computeApplicationFee(productPriceCents, fulfillmentCents, shippingCents);
+    const stripeFee = Math.round((productPriceCents + shippingCents) * STRIPE_PERCENT + STRIPE_FIXED);
+    expect(applicationFee).toBe(serviceFee + fulfillmentCents + shippingCents + stripeFee);
+  });
+
+  it("creatorNet = (productPriceCents + shippingCents) - applicationFee", () => {
+    const productPriceCents = 3000;
+    const { applicationFee, creatorNet } = computeApplicationFee(productPriceCents, 1200, 500);
+    expect(creatorNet).toBe(productPriceCents + 500 - applicationFee);
+  });
+
+  it("returns integers", () => {
+    const { applicationFee, serviceFee, creatorNet } = computeApplicationFee(3000, 1200, 500);
+    expect(Number.isInteger(applicationFee)).toBe(true);
+    expect(Number.isInteger(serviceFee)).toBe(true);
+    expect(Number.isInteger(creatorNet)).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #40

## Summary
- Product price is now computed once (`fixedProductPrice`) from markup only — no shipping in the formula, so it never changes when the buyer selects a shipping option
- Stripe line item uses the same server-side computed price; step 2 UI and Stripe match dollar-for-dollar
- Creator drop form now takes a **sale price** as input and shows estimated earnings below, instead of asking for a markup amount

## Test plan
- [ ] Visit a live drop — note the product price on step 1
- [ ] Fill in size + address, calculate shipping — product price unchanged from step 1
- [ ] Switch between shipping options — only shipping and total change, product stays fixed
- [ ] Click Buy — Stripe Checkout product line item matches step 2 UI exactly
- [ ] Create a new drop — enter a sale price and verify earnings estimate updates live

🤖 Generated with [Claude Code](https://claude.com/claude-code)