### PR TITLE
feat: support multi-item quantity in checkout

### DIFF
--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -27,6 +27,7 @@ const selectedRateSchema = z.object({
 const bodySchema = z.object({
   dropId: z.string().uuid(),
   size: z.enum(["S", "M", "L", "XL", "2XL"]),
+  quantity: z.number().int().min(1).max(10),
   address: addressSchema,
   selectedRate: selectedRateSchema,
   fulfillmentCents: z.number().int(),
@@ -45,7 +46,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Invalid request" }, { status: 400 })
   }
 
-  const { dropId, size, address, selectedRate, fulfillmentCents: clientFulfillmentCents } = parsed.data
+  const { dropId, size, quantity, address, selectedRate, fulfillmentCents: clientFulfillmentCents } = parsed.data
 
   const record = await db.query.drop.findFirst({ where: eq(drop.id, dropId) })
   if (!record || record.status !== "live") {
@@ -65,7 +66,11 @@ export async function POST(request: Request) {
 
   const shippingAmountCents = Math.round(parseFloat(selectedRate.rate) * 100)
   const productPriceCents = fixedProductPrice(record.markupCents)
-  const { applicationFee } = computeApplicationFee(productPriceCents, clientFulfillmentCents, shippingAmountCents)
+  const { applicationFee } = computeApplicationFee(
+    productPriceCents * quantity,
+    clientFulfillmentCents * quantity,
+    shippingAmountCents,
+  )
 
   const baseUrl = process.env.NEXT_PUBLIC_URL ?? "http://localhost:3000"
   const creatorSlug = creator.slug ?? creator.id
@@ -104,7 +109,7 @@ export async function POST(request: Request) {
           unit_amount: productPriceCents,
           product_data: { name: record.title },
         },
-        quantity: 1,
+        quantity,
       },
     ],
     shipping_options: shippingRateData,
@@ -116,6 +121,7 @@ export async function POST(request: Request) {
     metadata: {
       dropId,
       size,
+      quantity: String(quantity),
       buyerName: address.name,
       address: JSON.stringify(address),
       shippingRateId: selectedRate.id,

--- a/src/app/api/shipping-rates/route.ts
+++ b/src/app/api/shipping-rates/route.ts
@@ -11,6 +11,7 @@ import { BASE_SHIRT_COST_CENTS } from "@/lib/pricing"
 const bodySchema = z.object({
   dropId: z.string().uuid(),
   size: z.enum(["S", "M", "L", "XL", "2XL"]),
+  quantity: z.number().int().min(1).max(10),
   address: z.object({
     name: z.string().min(1),
     address1: z.string().min(1),
@@ -34,7 +35,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Invalid request" }, { status: 400 })
   }
 
-  const { dropId, size, address } = parsed.data
+  const { dropId, size, quantity, address } = parsed.data
 
   const record = await db.query.drop.findFirst({ where: eq(drop.id, dropId) })
   if (!record || record.status !== "live") {
@@ -57,7 +58,8 @@ export async function POST(request: Request) {
     countryCode: address.countryCode,
     zip: address.zip,
   }
-  const printfulItems = [{ variantId, quantity: 1 }]
+  const printfulItems = [{ variantId, quantity }]
+  const printfulItemsForCostEstimate = [{ variantId, quantity: 1 }]
 
   let rates: Awaited<ReturnType<typeof getShippingRates>>
   try {
@@ -74,7 +76,7 @@ export async function POST(request: Request) {
 
   let fulfillmentCents: number
   try {
-    fulfillmentCents = await estimateOrderCost(printfulAddress, printfulItems, printFileUrl)
+    fulfillmentCents = await estimateOrderCost(printfulAddress, printfulItemsForCostEstimate, printFileUrl)
   } catch (err) {
     if (err instanceof PrintfulError) {
       console.error("[shipping-rates] estimateOrderCost failed, falling back to base cost", { code: err.code, reason: err.reason, message: err.message })

--- a/src/components/drops/buy-form.tsx
+++ b/src/components/drops/buy-form.tsx
@@ -39,6 +39,7 @@ function formatCents(cents: number) {
 export function BuyForm({ dropId, productPriceCents }: BuyFormProps) {
   const [step, setStep] = useState<Step>("details")
   const [size, setSize] = useState<Size | null>(null)
+  const [quantity, setQuantity] = useState(1)
   const [isEditingSize, setIsEditingSize] = useState(true)
   const [isEditingAddress, setIsEditingAddress] = useState(false)
   const [address, setAddress] = useState<Address>({
@@ -66,7 +67,7 @@ export function BuyForm({ dropId, productPriceCents }: BuyFormProps) {
     const res = await fetch("/api/shipping-rates", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ dropId, size, address }),
+      body: JSON.stringify({ dropId, size, quantity, address }),
     })
     setLoading(false)
     if (res.ok) {
@@ -93,7 +94,7 @@ export function BuyForm({ dropId, productPriceCents }: BuyFormProps) {
     const res = await fetch("/api/checkout", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ dropId, size, address, selectedRate, fulfillmentCents }),
+      body: JSON.stringify({ dropId, size, quantity, address, selectedRate, fulfillmentCents }),
     })
     if (res.ok) {
       const { url } = (await res.json()) as { url: string }
@@ -124,7 +125,31 @@ export function BuyForm({ dropId, productPriceCents }: BuyFormProps) {
       >
         <div className="rounded-md bg-muted/40 px-4 py-3">
           <p className="text-sm text-muted-foreground">Product</p>
-          <p className="text-lg font-semibold">{formatCents(productPriceCents)} + shipping</p>
+          <p className="text-lg font-semibold">{formatCents(productPriceCents)} each + shipping</p>
+        </div>
+        <div className="rounded-md border border-border px-4 py-3">
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-sm font-medium">Quantity</p>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setQuantity((q) => Math.max(1, q - 1))}
+                className="flex h-7 w-7 items-center justify-center rounded-md border border-border text-sm hover:bg-muted disabled:opacity-40"
+                disabled={quantity <= 1}
+              >
+                −
+              </button>
+              <span className="w-6 text-center text-sm font-medium">{quantity}</span>
+              <button
+                type="button"
+                onClick={() => setQuantity((q) => Math.min(10, q + 1))}
+                className="flex h-7 w-7 items-center justify-center rounded-md border border-border text-sm hover:bg-muted disabled:opacity-40"
+                disabled={quantity >= 10}
+              >
+                +
+              </button>
+            </div>
+          </div>
         </div>
         <div className="rounded-md border border-border">
           <div className="flex items-center justify-between gap-3 px-4 py-3">
@@ -265,10 +290,11 @@ export function BuyForm({ dropId, productPriceCents }: BuyFormProps) {
   const priceBreakdown = (() => {
     if (!selectedRate) return null
     const shippingCents = Math.round(parseFloat(selectedRate.rate) * 100)
-    return { shippingCents, grandTotal: productPriceCents + shippingCents }
+    const productTotal = productPriceCents * quantity
+    return { shippingCents, productTotal, grandTotal: productTotal + shippingCents }
   })()
 
-  const buyTotalDisplay = priceBreakdown ? formatCents(priceBreakdown.grandTotal) : formatCents(productPriceCents)
+  const buyTotalDisplay = priceBreakdown ? formatCents(priceBreakdown.grandTotal) : formatCents(productPriceCents * quantity)
 
   return (
     <div className="flex flex-col gap-4">
@@ -298,8 +324,8 @@ export function BuyForm({ dropId, productPriceCents }: BuyFormProps) {
       {priceBreakdown && (
         <div className="rounded-md border border-border bg-muted/30 p-4 text-sm">
           <div className="flex items-center justify-between gap-3">
-            <span className="text-muted-foreground">Product</span>
-            <span className="font-medium">{formatCents(productPriceCents)}</span>
+            <span className="text-muted-foreground">Product × {quantity}</span>
+            <span className="font-medium">{formatCents(priceBreakdown.productTotal)}</span>
           </div>
           <div className="mt-2 flex items-center justify-between gap-3">
             <span className="text-muted-foreground">Shipping</span>

--- a/src/test/buy-form.test.tsx
+++ b/src/test/buy-form.test.tsx
@@ -56,12 +56,47 @@ describe("BuyForm rendering", () => {
 
   it("shows the fixed product price on the details step", async () => {
     await renderForm(2850)
-    expect(screen.getByText("$28.50 + shipping")).toBeInTheDocument()
+    expect(screen.getByText("$28.50 each + shipping")).toBeInTheDocument()
   })
 
   it("calculate shipping button is disabled before size and address are entered", async () => {
     await renderForm()
     expect(screen.getByRole("button", { name: /calculate shipping/i })).toBeDisabled()
+  })
+
+  it("renders quantity picker starting at 1", async () => {
+    await renderForm()
+    expect(screen.getByText("Quantity")).toBeInTheDocument()
+    expect(screen.getByText("1")).toBeInTheDocument()
+  })
+})
+
+// ─── Quantity picker ──────────────────────────────────────────────────────────
+
+describe("quantity picker", () => {
+  it("increments quantity up to 10", async () => {
+    await renderForm()
+    await userEvent.click(screen.getByRole("button", { name: "+" }))
+    expect(screen.getByText("2")).toBeInTheDocument()
+  })
+
+  it("decrement is disabled at quantity 1", async () => {
+    await renderForm()
+    expect(screen.getByRole("button", { name: "−" })).toBeDisabled()
+  })
+
+  it("increment is disabled at quantity 10", async () => {
+    await renderForm()
+    for (let i = 0; i < 9; i++) {
+      await userEvent.click(screen.getByRole("button", { name: "+" }))
+    }
+    expect(screen.getByRole("button", { name: "+" })).toBeDisabled()
+  })
+
+  it("decrement becomes enabled after incrementing", async () => {
+    await renderForm()
+    await userEvent.click(screen.getByRole("button", { name: "+" }))
+    expect(screen.getByRole("button", { name: "−" })).not.toBeDisabled()
   })
 })
 
@@ -117,7 +152,7 @@ describe("shipping step", () => {
     await renderForm()
     await goToShippingStep()
 
-    expect(screen.getByText("Product")).toBeInTheDocument()
+    expect(screen.getByText("Product × 1")).toBeInTheDocument()
     expect(screen.getByText("$34.05")).toBeInTheDocument()
     expect(screen.getByText("Shipping")).toBeInTheDocument()
     expect(screen.getAllByText("$5.99")).toHaveLength(2)
@@ -125,9 +160,21 @@ describe("shipping step", () => {
     expect(screen.getByRole("button", { name: /buy.*\$40\.04/i })).toBeInTheDocument()
   })
 
+  it("price breakdown scales with quantity", async () => {
+    await renderForm(3405)
+    await userEvent.click(screen.getByRole("button", { name: "+" }))
+    await userEvent.click(screen.getByRole("button", { name: "+" }))
+    await goToShippingStep()
+
+    // 3 × $34.05 = $102.15; shipping $5.99; total $108.14
+    expect(screen.getByText("Product × 3")).toBeInTheDocument()
+    expect(screen.getByText("$102.15")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /buy.*\$108\.14/i })).toBeInTheDocument()
+  })
+
   it("product price on step 2 matches step 1", async () => {
     await renderForm(3405)
-    expect(screen.getByText("$34.05 + shipping")).toBeInTheDocument()
+    expect(screen.getByText("$34.05 each + shipping")).toBeInTheDocument()
     await goToShippingStep()
     // step 1 unmounts; product row in breakdown must show the same price
     expect(screen.getByText("$34.05")).toBeInTheDocument()
@@ -141,6 +188,7 @@ describe("shipping step", () => {
     expect(url).toBe("/api/shipping-rates")
     const body = JSON.parse(init.body as string)
     expect(body.size).toBe("L")
+    expect(body.quantity).toBe(1)
     expect(body.address.name).toBe("Jane Doe")
   })
 
@@ -183,6 +231,36 @@ describe("checkout submission", () => {
       expect(body.size).toBe("L")
       expect(body.selectedRate.id).toBe("STANDARD")
     })
+  })
+
+  it("POSTs quantity to /api/checkout", async () => {
+    await renderForm()
+    await userEvent.click(screen.getByRole("button", { name: "+" }))
+    await userEvent.click(screen.getByRole("button", { name: "+" }))
+    await goToShippingStep()
+
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ url: "https://checkout.stripe.com/session" }), { status: 200 }),
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: /buy/i }))
+
+    await waitFor(() => {
+      const checkoutCall = vi.mocked(global.fetch).mock.calls[1] as [string, RequestInit]
+      const body = JSON.parse(checkoutCall[1].body as string)
+      expect(body.quantity).toBe(3)
+    })
+  })
+
+  it("sends quantity to /api/shipping-rates when fetching rates", async () => {
+    await renderForm()
+    await userEvent.click(screen.getByRole("button", { name: "+" }))
+    await goToShippingStep()
+
+    const shippingCall = vi.mocked(global.fetch).mock.calls[0] as [string, RequestInit]
+    expect(shippingCall[0]).toBe("/api/shipping-rates")
+    const body = JSON.parse(shippingCall[1].body as string)
+    expect(body.quantity).toBe(2)
   })
 
   it("shows Redirecting… while awaiting checkout response", async () => {

--- a/src/test/checkout.test.ts
+++ b/src/test/checkout.test.ts
@@ -81,6 +81,7 @@ function validBody(overrides?: Record<string, unknown>) {
   return {
     dropId: DROP_ID,
     size: "M",
+    quantity: 1,
     address: ADDRESS,
     selectedRate: SELECTED_RATE,
     fulfillmentCents: 1350,
@@ -220,6 +221,57 @@ describe("POST /api/checkout", () => {
           metadata: expect.objectContaining({ shippingCents: "599" }),
         }),
       )
+    })
+
+    it("stores quantity in Stripe session metadata", async () => {
+      const { POST } = await import("@/app/api/checkout/route")
+      await POST(makeRequest(validBody({ quantity: 3 })))
+      expect(mockSessionsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({ quantity: "3" }),
+        }),
+      )
+    })
+
+    it("passes quantity to Stripe line_items", async () => {
+      const { POST } = await import("@/app/api/checkout/route")
+      await POST(makeRequest(validBody({ quantity: 2 })))
+      expect(mockSessionsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          line_items: expect.arrayContaining([
+            expect.objectContaining({ quantity: 2 }),
+          ]),
+        }),
+      )
+    })
+
+    it("scales productPriceCents and fulfillmentCents by quantity for application fee", async () => {
+      mockFixedProductPrice.mockReturnValue(2800)
+      const { POST } = await import("@/app/api/checkout/route")
+      await POST(makeRequest(validBody({ quantity: 3, fulfillmentCents: 1350 })))
+      expect(mockComputeApplicationFee).toHaveBeenCalledWith(2800 * 3, 1350 * 3, expect.any(Number))
+    })
+  })
+
+  describe("quantity validation", () => {
+    it("returns 400 when quantity is missing", async () => {
+      const { POST } = await import("@/app/api/checkout/route")
+      const body = validBody()
+      delete (body as Record<string, unknown>).quantity
+      const res = await POST(makeRequest(body))
+      expect(res.status).toBe(400)
+    })
+
+    it("returns 400 when quantity is 0", async () => {
+      const { POST } = await import("@/app/api/checkout/route")
+      const res = await POST(makeRequest(validBody({ quantity: 0 })))
+      expect(res.status).toBe(400)
+    })
+
+    it("returns 400 when quantity exceeds 10", async () => {
+      const { POST } = await import("@/app/api/checkout/route")
+      const res = await POST(makeRequest(validBody({ quantity: 11 })))
+      expect(res.status).toBe(400)
     })
   })
 })

--- a/src/test/shipping-rates.test.ts
+++ b/src/test/shipping-rates.test.ts
@@ -51,6 +51,7 @@ function validBody(overrides?: Record<string, unknown>) {
   return {
     dropId: DROP_ID,
     size: "M",
+    quantity: 1,
     address: {
       name: "Jane Doe",
       address1: "1 Main St",
@@ -88,6 +89,26 @@ describe("POST /api/shipping-rates", () => {
     it("returns 400 on invalid size", async () => {
       const { POST } = await import("@/app/api/shipping-rates/route")
       const res = await POST(makeRequest(validBody({ size: "XXXL" })))
+      expect(res.status).toBe(400)
+    })
+
+    it("returns 400 when quantity is missing", async () => {
+      const { POST } = await import("@/app/api/shipping-rates/route")
+      const body = validBody()
+      delete (body as Record<string, unknown>).quantity
+      const res = await POST(makeRequest(body))
+      expect(res.status).toBe(400)
+    })
+
+    it("returns 400 when quantity is 0", async () => {
+      const { POST } = await import("@/app/api/shipping-rates/route")
+      const res = await POST(makeRequest(validBody({ quantity: 0 })))
+      expect(res.status).toBe(400)
+    })
+
+    it("returns 400 when quantity exceeds 10", async () => {
+      const { POST } = await import("@/app/api/shipping-rates/route")
+      const res = await POST(makeRequest(validBody({ quantity: 11 })))
       expect(res.status).toBe(400)
     })
 
@@ -129,6 +150,20 @@ describe("POST /api/shipping-rates", () => {
       const ratesAddr = mockGetShippingRates.mock.calls[0][0]
       const estimateAddr = mockEstimateOrderCost.mock.calls[0][0]
       expect(ratesAddr).toEqual(estimateAddr)
+    })
+
+    it("passes the requested quantity to getShippingRates", async () => {
+      const { POST } = await import("@/app/api/shipping-rates/route")
+      await POST(makeRequest(validBody({ quantity: 3 })))
+      const items = mockGetShippingRates.mock.calls[0][1] as { quantity: number }[]
+      expect(items[0].quantity).toBe(3)
+    })
+
+    it("always passes quantity 1 to estimateOrderCost regardless of requested quantity", async () => {
+      const { POST } = await import("@/app/api/shipping-rates/route")
+      await POST(makeRequest(validBody({ quantity: 3 })))
+      const items = mockEstimateOrderCost.mock.calls[0][1] as { quantity: number }[]
+      expect(items[0].quantity).toBe(1)
     })
   })
 


### PR DESCRIPTION
Closes #33

## Summary

- Buyers can select 1–10 items via a quantity picker on the buy form
- Shipping rates are fetched from Printful with the actual quantity, so the buyer sees the correct shipping cost for their order size
- Application fee scaled correctly: `productPriceCents * quantity` + `fulfillmentCents * quantity` (fulfillment cost remains per-unit from Printful, scaled in checkout)
- Stripe line item passes `quantity`; `unit_amount` stays per-unit as required
- `FULFILLMENT_MAX_CENTS` guard remains a per-unit bound (unchanged)
- Price breakdown on step 2 shows "Product × N" with correct total

## Test plan

- [ ] Quantity picker renders at 1, − disabled, + enabled
- [ ] Increment/decrement work; + disables at 10, − disables at 1
- [ ] "Calculate shipping" sends quantity to `/api/shipping-rates`
- [ ] Price breakdown shows `Product × N` and correct scaled total
- [ ] "Buy" sends quantity to `/api/checkout`
- [ ] Stripe session receives correct `quantity` on line item and in metadata
- [ ] `computeApplicationFee` called with scaled product + fulfillment costs
- [ ] Schema rejects quantity 0, quantity 11, missing quantity (both routes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)