### PR TITLE
fix: use front_large dimensions and clamp compositor bounds

### DIFF
--- a/src/lib/compositor.ts
+++ b/src/lib/compositor.ts
@@ -1,8 +1,8 @@
 import sharp from "sharp";
 import { downloadFile, uploadFile, storageKeys } from "./storage";
 
-// Printful BC 3001 front print area spec (px at 150 DPI)
-export const PRINT_CANVAS = { width: 1800, height: 2400 } as const;
+// Printful BC 3001 front_large print area spec: 15" × 18" at 150 DPI
+export const PRINT_CANVAS = { width: 2250, height: 2700 } as const;
 
 export type Placement = {
   x: number;
@@ -29,13 +29,38 @@ export async function compositePrintFile(
   const scaledWidth = Math.round(designWidth * placement.scale);
   const scaledHeight = Math.round(designHeight * placement.scale);
 
-  const resized = await sharp(workingBuffer)
-    .resize(scaledWidth, scaledHeight, { fit: "fill" })
-    .png()
-    .toBuffer();
-
   const left = Math.round(placement.x);
   const top = Math.round(placement.y);
+
+  // Compute visible region of the scaled design within the canvas bounds
+  const visLeft = Math.max(0, -left);
+  const visTop = Math.max(0, -top);
+  const visRight = Math.min(scaledWidth, PRINT_CANVAS.width - left);
+  const visBottom = Math.min(scaledHeight, PRINT_CANVAS.height - top);
+  const visW = visRight - visLeft;
+  const visH = visBottom - visTop;
+
+  const compositeInput: Parameters<ReturnType<typeof sharp>["composite"]>[0] = [];
+
+  if (visW > 0 && visH > 0) {
+    // Extract only the visible portion from the working buffer (in natural coords)
+    // to avoid creating huge intermediate images when scale is large
+    const natLeft = Math.round(visLeft / placement.scale);
+    const natTop = Math.round(visTop / placement.scale);
+    const natW = Math.min(Math.max(1, Math.round(visW / placement.scale)), designWidth - natLeft);
+    const natH = Math.min(Math.max(1, Math.round(visH / placement.scale)), designHeight - natTop);
+
+    const cropped = await sharp(workingBuffer)
+      .extract({ left: natLeft, top: natTop, width: natW, height: natH })
+      .toBuffer();
+
+    const resized = await sharp(cropped)
+      .resize(visW, visH, { fit: "fill" })
+      .png()
+      .toBuffer();
+
+    compositeInput.push({ input: resized, left: Math.max(0, left), top: Math.max(0, top) });
+  }
 
   const composited = await sharp({
     create: {
@@ -45,7 +70,7 @@ export async function compositePrintFile(
       background: { r: 0, g: 0, b: 0, alpha: 0 },
     },
   })
-    .composite([{ input: resized, left, top }])
+    .composite(compositeInput)
     .png()
     .toBuffer();
 

--- a/src/lib/design-constants.ts
+++ b/src/lib/design-constants.ts
@@ -1,24 +1,24 @@
-// BC 3001 front print area: 12" × 16" @ 150 DPI minimum
-export const PRINT_INCHES_W = 12
-export const PRINT_INCHES_H = 16
-export const MIN_DPI = 150
-export const MIN_PX_W = PRINT_INCHES_W * MIN_DPI // 1800
-export const MIN_PX_H = PRINT_INCHES_H * MIN_DPI // 2400
+// BC 3001 front_large print area: 15" × 18" @ 150 DPI minimum
+export const PRINT_INCHES_W = 15;
+export const PRINT_INCHES_H = 18;
+export const MIN_DPI = 150;
+export const MIN_PX_W = PRINT_INCHES_W * MIN_DPI; // 2250
+export const MIN_PX_H = PRINT_INCHES_H * MIN_DPI; // 2700
 
 // Print area position on the 1000×1000 t-shirt template (fraction of image size)
 export const PRINT_AREA = {
-  left: 0.30,
-  top: 0.24,
-  width: 0.40,
-  height: 0.53,
-} as const
+  left: 0.27,
+  top: 0.19,
+  width: 0.45,
+  height: 0.54,
+} as const;
 
 // Display size of the t-shirt image inside the modal
-export const TSHIRT_DISPLAY = 320
+export const TSHIRT_DISPLAY = 320;
 
 export type Placement = {
-  x: number
-  y: number
-  scale: number
-  rotate: number
-}
+  x: number;
+  y: number;
+  scale: number;
+  rotate: number;
+};

--- a/src/lib/printful.ts
+++ b/src/lib/printful.ts
@@ -122,7 +122,7 @@ export async function submitOrder(params: SubmitOrderParams): Promise<PrintfulOr
         items: params.items.map((item) => ({
           variant_id: item.variantId,
           quantity: item.quantity,
-          files: [{ type: "front", url: item.printFileUrl }],
+          files: [{ type: "front_large", url: item.printFileUrl }],
         })),
       }),
     },
@@ -156,13 +156,13 @@ export async function generatePrintfulMockupUrl(
         variant_ids: variantIds,
         files: [
           {
-            placement: "front",
+            placement: "front_large",
             image_url: printFileUrl,
             position: {
-              area_width: 1800,
-              area_height: 2400,
-              width: 1800,
-              height: 2400,
+              area_width: 2250,
+              area_height: 2700,
+              width: 2250,
+              height: 2700,
               top: 0,
               left: 0,
             },
@@ -184,7 +184,7 @@ export async function generatePrintfulMockupUrl(
       )
 
       if (result.status === "completed") {
-        const url = result.mockups?.find((m) => m.placement === "front")?.mockup_url
+        const url = result.mockups?.find((m) => m.placement === "front_large")?.mockup_url
         if (!url) throw new PrintfulError(0, "no_mockup", "No front mockup in Printful response")
         return url
       }

--- a/src/test/compositor.test.ts
+++ b/src/test/compositor.test.ts
@@ -75,8 +75,9 @@ describe("compositePrintFile", () => {
       .raw()
       .toBuffer({ resolveWithObject: true });
 
-    // pixel at (50, 50): offset = (50 * 1800 + 50) * 4
-    const offset = (50 * 1800 + 50) * 4;
+    // pixel at (50, 50): offset = (50 * PRINT_CANVAS.width + 50) * 4
+    const { PRINT_CANVAS } = await import("../lib/compositor");
+    const offset = (50 * PRINT_CANVAS.width + 50) * 4;
     expect(data[offset]).toBe(255); // R
     expect(data[offset + 1]).toBe(0); // G
     expect(data[offset + 2]).toBe(0); // B
@@ -96,7 +97,8 @@ describe("compositePrintFile", () => {
       .raw()
       .toBuffer({ resolveWithObject: true });
 
-    const offset = (650 * 1800 + 550) * 4;
+    const { PRINT_CANVAS: PC } = await import("../lib/compositor");
+    const offset = (650 * PC.width + 550) * 4;
     expect(data[offset]).toBe(255);
     expect(data[offset + 1]).toBe(0);
     expect(data[offset + 2]).toBe(0);
@@ -134,6 +136,37 @@ describe("compositePrintFile", () => {
     expect(mockDownloadFile).toHaveBeenCalledWith("designs/my-design.png");
   });
 
+  it("does not throw when scaled design exceeds canvas bounds (large PNG)", async () => {
+    // 100×100 design at scale=30 → 3000×3000, larger than 2250 canvas width
+    const design = await makePng(100, 100);
+    mockDownloadFile.mockResolvedValue(design);
+    mockUploadFile.mockResolvedValue(undefined);
+
+    const { compositePrintFile, PRINT_CANVAS } = await import("../lib/compositor");
+    await expect(
+      compositePrintFile("designs/large.png", { x: 0, y: 0, scale: 30, rotate: 0 })
+    ).resolves.not.toThrow();
+
+    const uploaded: Buffer = mockUploadFile.mock.calls[0][1];
+    const meta = await sharp(uploaded).metadata();
+    expect(meta.width).toBe(PRINT_CANVAS.width);
+    expect(meta.height).toBe(PRINT_CANVAS.height);
+  });
+
+  it("design placed partially outside canvas (negative offset) composites correctly", async () => {
+    const design = await makePng(100, 100);
+    mockDownloadFile.mockResolvedValue(design);
+    mockUploadFile.mockResolvedValue(undefined);
+
+    const { compositePrintFile, PRINT_CANVAS } = await import("../lib/compositor");
+    await compositePrintFile("designs/test.png", { x: -50, y: -50, scale: 1, rotate: 0 });
+
+    const uploaded: Buffer = mockUploadFile.mock.calls[0][1];
+    const meta = await sharp(uploaded).metadata();
+    expect(meta.width).toBe(PRINT_CANVAS.width);
+    expect(meta.height).toBe(PRINT_CANVAS.height);
+  });
+
   it("applies rotation — 90° rotate swaps image dimensions before composite", async () => {
     // 200×100 image rotated 90° becomes 100×200
     const design = await makePng(200, 100);
@@ -146,7 +179,8 @@ describe("compositePrintFile", () => {
     const uploaded: Buffer = mockUploadFile.mock.calls[0][1];
     const meta = await sharp(uploaded).metadata();
     // Canvas is always PRINT_CANVAS size regardless of rotation
-    expect(meta.width).toBe(1800);
-    expect(meta.height).toBe(2400);
+    const { PRINT_CANVAS: ROT_CANVAS } = await import("../lib/compositor");
+    expect(meta.width).toBe(ROT_CANVAS.width);
+    expect(meta.height).toBe(ROT_CANVAS.height);
   });
 });


### PR DESCRIPTION
Switch print area spec from front (12"×16") to front_large (15"×18"), updating PRINT_CANVAS to 2250×2700, Printful API placement/position fields, and PRINT_AREA fractions to match the larger print area.

Fix Sharp crash when a scaled design exceeds the canvas dimensions by extracting only the visible canvas-intersecting region before resizing, avoiding huge intermediate buffers and out-of-bounds compositing.

Closes #50